### PR TITLE
Feature mib refactor

### DIFF
--- a/momo_modules/field_service_unit/src/debug/command_handlers.c
+++ b/momo_modules/field_service_unit/src/debug/command_handlers.c
@@ -266,38 +266,45 @@ void handle_rpc(command_params *params)
         return;
     }
 
+    /*unsigned int argc = params->num_params - 2;
+    if ( argc > 3 ) {
+        print( "A maximum of 3 params is allowed\n" );
+        return;
+    }
+    int i;
+    int intParams[3];
+    char* bufferParam = NULL;
+
+    for ( i=2; i<params->num_params; ++i) {
+        int d;
+        char* str = get_param_string( params, i );
+        if ( !atoi_small( str, &intParams[i-2] ) ) {
+            if ( i == params->num_params-1 ) {
+                bufferParam = str;
+            } else {
+                print( "Only one param can be a buffer, and it must be the last param.\n" );
+                return;
+            }
+        }
+    }
+
+    unsigned char plist = plist_define0();
+    unsigned char lastParamType = ((bufferParam==NULL)?kMIBInt16Type:kMIBBufferType);
+    if ( argc == 1 ) {
+        plist = plist_define1( lastParamType );
+    } else if ( argc == 2 ) {
+        plist = plist_define2( kMIBInt16Type, lastParamType );
+    } else {// argc == 3
+        plist = plist_define3( kMIBInt16Type, kMIBInt16Type, lastParamType );
+    }*/
+
     // For now, only support two random int params - the test blink RPC accepts this
     bus_master_compose_params(plist_define2(kMIBInt16Type, kMIBInt16Type));
     set_intparam(0, 6);
     set_intparam(1, 5);
+
+    
     
     bus_master_rpc_async(NULL, kControllerPICAddress, feature&0xFF, command&0xFF);
     print( "Sending RPC...\n" );
-
-/*
-    MIBIntParameter     rpc_params[3]; //Hacky, but ok.  We'll forcibly make it a BufferParameter if we have to
-    MIBParameterHeader *rpc_param_headers[3];
-    rpc_param_headers[0] = &rpc_params[0].header;
-    rpc_param_headers[1] = &rpc_params[1].header;
-    rpc_param_headers[2] = &rpc_params[2].header;
-
-    unsigned int argc = params->num_params - 2;
-    int i;
-    for ( i=2; i<params->num_params; ++i) {
-        int d;
-        char* str = get_param_string( params, i );
-        if ( atoi_small( str, &i ) ) {
-            bus_init_int_param(&rpc_params[i], d);
-        } else {
-            bus_init_buffer_param( (MIBBufferParameter*) &rpc_params[i], str, strlen( str ) ); // I think I'm actually disgusted.
-        }
-    }
-
-    waiting_for_rpc_return = true;
-    bus_master_rpc(rpc_callback, kControllerPICAddress, feature, command, rpc_param_headers, argc);
-
-    int timeout = 10000;
-    while (waiting_for_rpc_return && timeout > 0)
-        --timeout;
-    */
 }

--- a/momo_modules/field_service_unit/src/debug/command_handlers.c
+++ b/momo_modules/field_service_unit/src/debug/command_handlers.c
@@ -298,6 +298,8 @@ void handle_rpc(command_params *params)
         plist = plist_define3( kMIBInt16Type, kMIBInt16Type, lastParamType );
     }*/
 
+    //TODO: Possibly listen for a ton of bytes here, we need to support sending over large firmware files.
+
     // For now, only support two random int params - the test blink RPC accepts this
     bus_master_compose_params(plist_define2(kMIBInt16Type, kMIBInt16Type));
     set_intparam(0, 6);

--- a/momo_modules/field_service_unit/src/debug/command_handlers.c
+++ b/momo_modules/field_service_unit/src/debug/command_handlers.c
@@ -270,8 +270,9 @@ void handle_rpc(command_params *params)
     bus_master_compose_params(plist_define2(kMIBInt16Type, kMIBInt16Type));
     set_intparam(0, 6);
     set_intparam(1, 5);
-
-    bus_master_rpc_async(NULL, kControllerPICAddress, 0x2, 0x1);
+    
+    bus_master_rpc_async(NULL, kControllerPICAddress, feature&0xFF, command&0xFF);
+    print( "Sending RPC...\n" );
 
 /*
     MIBIntParameter     rpc_params[3]; //Hacky, but ok.  We'll forcibly make it a BufferParameter if we have to
@@ -298,6 +299,5 @@ void handle_rpc(command_params *params)
     int timeout = 10000;
     while (waiting_for_rpc_return && timeout > 0)
         --timeout;
->>>>>>> 241aef35421fb42d8048139c0c0e0f4312ad4468*/
-    return;
+    */
 }

--- a/momo_modules/field_service_unit/src/main.c
+++ b/momo_modules/field_service_unit/src/main.c
@@ -59,20 +59,6 @@ void alive(void)
 
 ScheduledTask task;
 
-void send_blink_message(void)
-{
-    MIBIntParameter param1;
-    MIBIntParameter param2;
-    MIBParameterHeader *params[2];
-
-    params[0] = (MIBParameterHeader*)&param1;
-    params[1] = (MIBParameterHeader*)&param2;
-
-    bus_init_int_param(&param1, 5);
-    bus_init_int_param(&param2, 6);
-    bus_master_rpc(NULL, 8, 0x02, 0x01, params, 2);
-}
-
 int main(void) {
     AD1PCFG = 0xFFFF;
     _TRISA4 = 0;
@@ -82,7 +68,7 @@ int main(void) {
     handle_reset();
 
     //scheduler_schedule_task(alive, kEverySecond, kScheduleForever, &task);
-    scheduler_schedule_task(send_blink_message, kEverySecond, kScheduleForever, &task);
+    //scheduler_schedule_task(send_blink_message, kEverySecond, kScheduleForever, &task);
 
     taskloop_loop();
 

--- a/momo_modules/mainboard/src/main.c
+++ b/momo_modules/mainboard/src/main.c
@@ -123,12 +123,12 @@ int main(void)
     _TRISB0 = 0;
 
     _RA1 = 0;
-    _RA0 = 1;
+    _RA0 = 0;
 
     register_reset_handlers();
     handle_reset();
 
-    //scheduler_schedule_task(blink_light1, kEverySecond, kScheduleForever, &task1);
+    scheduler_schedule_task(blink_light1, kEverySecond, kScheduleForever, &task1);
     //scheduler_schedule_task(send_blink_message, kEverySecond, kScheduleForever, &i2c);
 
     taskloop_loop();

--- a/momo_modules/mainboard/src/mib/mainboard_mib_commands.c
+++ b/momo_modules/mainboard/src/mib/mainboard_mib_commands.c
@@ -1,33 +1,4 @@
 #include "mainboard_mib_commands.h"
-<<<<<<< HEAD
-//#include "mib_command.h"
-//#include "mib_command_parameters.h"
-
-#include "test.h"
-#include "prog.h"
-/*
-#define kTestCommandCount 2
-static mib_command_handler test_commands[kTestCommandCount] =
-	{
-		{0, echo_buffer, plist_define1(kMIBBufferType) },
-		{1, test_command, plist_define2(kMIBInt16Type, kMIBInt16Type) }
-	};
-
-#define kProgrammingCommandCount 3
-static mib_command_handler programming_commands[kProgrammingCommandCount] = 
-	{
-		{0, erase_primaryfirmware, plist_define0() },
-		{1, load_into_nvram, plist_define3(kMIBInt16Type, kMIBInt16Type, kMIBBufferType) },
-		{2, read_from_nvram, plist_define3(kMIBInt16Type, kMIBInt16Type, kMIBInt16Type) }
-	};
-
-static feature_map mainboard_mib_features[kMainboardMIBFeatureCount] =
-	{
-		{kMIBTestFeature, test_commands, kTestCommandCount},
-		{kMIBProgrammingFeature, programming_commands, kProgrammingCommandCount}
-	};
-=======
-*/
 #include "mib_features.h"
 
 DEFINE_FEATURE_MAP()
@@ -39,6 +10,5 @@ DEFINE_FEATURE_MAP()
 
 void init_mainboard_mib()
 {
-	register_mib_features(mainboard_mib_features, kMainboardMIBFeatureCount);
 	REGISTER_FEATURE_MAP();
 }

--- a/momo_modules/shared/pic24/src/mib/commands/controller_mib_feature.c
+++ b/momo_modules/shared/pic24/src/mib/commands/controller_mib_feature.c
@@ -1,6 +1,7 @@
 #include "bus_slave.h"
 #include "controller_mib_feature.h"
 #include <string.h>
+#include "memory.h"
 
 #include "mib_features.h"
 
@@ -61,9 +62,84 @@ void describe_module(void)
 	bus_slave_setreturn( kNoMIBError | kHasReturnValue );
 }
 
+void cleanup_unresponsive_modules() // Schedule periodically
+{
+	//TODO: Ping all assigned addresses and dump the ones that don't respond.
+}
+
+typedef struct {
+	uint8 		  module_type; // Registered module address instead?
+	uint8 		  last_sequence;
+	unsigned long firmware_length;
+	unsigned long base_address;
+	unsigned long offset_bytes;
+} firmware_bucket;
+#define kFirmwareDumpedSuccessfully 0
+#define kFirmwareBucketBaseAddress  0xFF
+static firmware_bucket the_firmware_bucket = {0,0,0,kFirmwareBucketBaseAddress}; //TODO: Move somewhere better, have multiple buckets.
+
+void start_dump_firmware(void)
+{
+	unsigned long p0 = get_uint16_param(0);
+
+	uint8 module_type = p0 >> 8;
+	uint8 sequence_number = p0 & 0xFF; // Should be 0 for a start.
+	if ( the_firmware_bucket.module_type == 0 && sequence_number == 0) {
+		the_firmware_bucket.module_type = module_type;
+		the_firmware_bucket.last_sequence = 0;
+		the_firmware_bucket.firmware_length = get_uint16_param(1);
+	} else {
+		// ERROR, until we have multiple buckets
+	}
+
+	//Should we just say "ok" before starting to actually get the firmware?
+	MIBBufferParameter *data = get_buffer_param(2);
+	mem_write( /*address*/the_firmware_bucket.base_address+the_firmware_bucket.offset_bytes, data->data, data->header.len ); // Synchronous.  Probably ok?
+	the_firmware_bucket.offset_bytes += data->header.len;
+
+	loadparams(plist_1param(kMIBInt16Type));
+	set_intparam( 0, the_firmware_bucket.offset_bytes ); // We expect the caller to use this new offset to call us again with the next chunk
+
+	bus_slave_setreturn( kNoMIBError | kHasReturnValue );
+}
+
+void dump_firmware_chunk(void)
+{
+	unsigned long p0 = get_uint16_param(0);
+
+	uint8 module_type = p0 >> 8;
+	uint8 sequence_number = p0 & 0xFF;
+	if ( module_type != the_firmware_bucket.module_type
+	     || the_firmware_bucket.offset_bytes == kFirmwareDumpedSuccessfully ) {
+		// ERROR, until we have multiple buckets
+	}
+
+	MIBBufferParameter *data = get_buffer_param(1);
+	mem_write( /*address*/the_firmware_bucket.base_address+the_firmware_bucket.offset_bytes, data->data, data->header.len ); // Synchronous.  Probably ok?
+	the_firmware_bucket.offset_bytes += data->header.len;
+	the_firmware_bucket.last_sequence = sequence_number;
+
+	//TODO: What happens if we get an invalid sequence number...?
+
+	if ( the_firmware_bucket.offset_bytes >= the_firmware_bucket.firmware_length ) {
+		// We're done.  TODO: Notify people.
+		the_firmware_bucket.offset_bytes = kFirmwareDumpedSuccessfully;
+		the_firmware_bucket.last_sequence = 0;
+	}
+
+	loadparams(plist_1param(kMIBInt16Type));
+	set_intparam( 0, the_firmware_bucket.offset_bytes ); // We expect the caller to use this new offset to call us again with the next chunk
+
+	bus_slave_setreturn( kNoMIBError | kHasReturnValue );
+}
+
+
+
 DEFINE_MIB_FEATURE_COMMANDS(controller) {
-	{0, register_module, plist_define1(kMIBBufferType) },
-	{1, get_module_count, plist_define0() },
-	{2, describe_module, plist_define1(kMIBInt16Type) }
+	{0x00, register_module, plist_define1(kMIBBufferType) },
+	{0x01, get_module_count, plist_define0() },
+	{0x02, describe_module, plist_define1(kMIBInt16Type) },
+	{0x10, start_dump_firmware, plist_define3(kMIBInt16Type,kMIBInt16Type,kMIBBufferType) },
+	{0x11, dump_firmware_chunk, plist_define2(kMIBInt16Type,kMIBBufferType) }
 };
 DEFINE_MIB_FEATURE(controller);

--- a/momo_modules/shared/pic24/src/mib/commands/controller_mib_feature.h
+++ b/momo_modules/shared/pic24/src/mib/commands/controller_mib_feature.h
@@ -2,11 +2,13 @@
 #define __controller_mib_feature_h
 
 typedef struct {
-	unsigned int id;
-	char name[8];
+	unsigned int type;
+	char 		 name[8];
 	unsigned int version;
 	unsigned int feature_count;
 	unsigned int features[8];
 } momo_module_descriptor;
+
+void cleanup_unresponsive_modules();
 
 #endif

--- a/momo_modules/shared/pic24/src/mib/mib_hal.c
+++ b/momo_modules/shared/pic24/src/mib/mib_hal.c
@@ -15,7 +15,6 @@ extern unsigned int the_feature_count;
 uint8 find_handler(void)
 {
 	uint8 i, j, num_cmds;
-	uint8 cmd = mib_state.bus_command.command;
 
 	for (i=0; i<the_feature_count; ++i)
 	{

--- a/momo_modules/shared/pic24/src/mib/slave/commands/prog.c
+++ b/momo_modules/shared/pic24/src/mib/slave/commands/prog.c
@@ -2,8 +2,6 @@
 #include "memory.h"
 #include "prog.h"
 #include "bootloader.h"
-
-#include "mib_features.h"
 /*
  * Erase the pic24 program portion of the flash memory
  *

--- a/momo_modules/shared/pic24/src/mib/slave/commands/prog.h
+++ b/momo_modules/shared/pic24/src/mib/slave/commands/prog.h
@@ -1,13 +1,10 @@
 #ifndef __prog_h
 #define __prog_h
 
-<<<<<<< HEAD
-#include "protocol.h"
+#include "mib_feature_definition.h"
 
-void erase_primaryfirmware(void);
-void load_into_nvram(void);
-void read_from_nvram(void);
+//void erase_primaryfirmware(void);
+//void load_into_nvram(void);
+//void read_from_nvram(void);
 
-=======
->>>>>>> 241aef35421fb42d8048139c0c0e0f4312ad4468
 #endif

--- a/momo_modules/shared/pic24/src/mib/slave/commands/test.c
+++ b/momo_modules/shared/pic24/src/mib/slave/commands/test.c
@@ -3,15 +3,7 @@
 #include "test.h"
 #include <string.h>
 
-<<<<<<< HEAD
 void test_command(void)
-=======
-#include "mib_features.h"
-
-extern volatile unsigned char 	mib_buffer[kBusMaxMessageSize];
-
-void* test_command(MIBParamList *param)
->>>>>>> 241aef35421fb42d8048139c0c0e0f4312ad4468
 {
 	_RA1 = !_RA1; //Blink light
 	
@@ -28,13 +20,7 @@ void echo_buffer(void)
 	memmove((void*)mib_buffer, buf, 2);
 	memmove((void*)mib_buffer+2, buf->data, buf->header.len);
 
-<<<<<<< HEAD
 	bus_slave_setreturn(kNoMIBError| kHasReturnValue);
-}
-=======
-	bus_slave_setreturn(kNoMIBError, (MIBParameterHeader*)mib_buffer);
-
-	return NULL;
 }
 
 DEFINE_MIB_FEATURE_COMMANDS(test)
@@ -43,4 +29,3 @@ DEFINE_MIB_FEATURE_COMMANDS(test)
 	{1, test_command, plist_define2(kMIBInt16Type, kMIBInt16Type) }
 };
 DEFINE_MIB_FEATURE(test);
->>>>>>> 241aef35421fb42d8048139c0c0e0f4312ad4468

--- a/momo_modules/shared/pic24/src/mib/slave/commands/test.h
+++ b/momo_modules/shared/pic24/src/mib/slave/commands/test.h
@@ -1,12 +1,6 @@
 #ifndef __test_h
 #define __test_h
 
-<<<<<<< HEAD
-#include "protocol.h"
+#include "mib_feature_definition.h"
 
-void test_command(void);
-void echo_buffer(void);
-
-=======
->>>>>>> 241aef35421fb42d8048139c0c0e0f4312ad4468
 #endif

--- a/momo_modules/shared/portable/mib/bus.h
+++ b/momo_modules/shared/portable/mib/bus.h
@@ -53,8 +53,11 @@ typedef struct
 	MIBCommandPacket		bus_command;
 	I2CMessage				bus_msg;
 	MIBReturnValueHeader	bus_returnstatus;
-	
+
 	//handlers
+#ifndef _PIC12 //TODO: Also on PIC12?
+	uint8					feature_index;
+#endif
 	uint8					slave_handler;
 	
 	//PIC12 does not support ascynchronous master RPCs

--- a/momo_modules/shared/portable/mib/mib_feature.c
+++ b/momo_modules/shared/portable/mib/mib_feature.c
@@ -1,0 +1,10 @@
+#include "mib_feature.h"
+
+const feature_map** the_features;
+unsigned int the_feature_count;
+
+void register_mib_features( const feature_map** features, unsigned int count )
+{
+	the_features = features;
+	the_feature_count = count;
+}

--- a/momo_modules/shared/portable/mib/mib_feature.h
+++ b/momo_modules/shared/portable/mib/mib_feature.h
@@ -1,8 +1,19 @@
 #ifndef __mib_feature_h
 #define __mib_feature_h
 
-#include "mib_command.h"
-#include "mib_command_parameters.h"
+#include "protocol.h"
+
+typedef struct {
+	unsigned char id;
+	mib_callback handler;
+	unsigned char params;
+} mib_command_handler;
+
+typedef struct {
+	unsigned char id;
+	unsigned short command_count;
+	mib_command_handler* commands;
+} feature_map;
 
 #define MIB_FEATURE_CMD_MAP(name) mib_feature_##name##_commands
 #define MIB_FEATURE_OBJ(name) mib_feature_##name
@@ -12,11 +23,13 @@
 #define DEFINE_MIB_FEATURE_COMMANDS(name) static mib_command_handler MIB_FEATURE_CMD_MAP(name) [] = 
 #define MIB_FEATURE_CMD_COUNT(name) (sizeof(MIB_FEATURE_CMD_MAP(name))/sizeof(mib_command_handler))
 
-#define DEFINE_MIB_FEATURE(name) feature_map MIB_FEATURE_OBJ(name) = {MIB_FEATURE_ID(name), MIB_FEATURE_CMD_MAP(name), MIB_FEATURE_CMD_COUNT(name)};
+#define DEFINE_MIB_FEATURE(name) feature_map MIB_FEATURE_OBJ(name) = { MIB_FEATURE_ID(name), MIB_FEATURE_CMD_COUNT(name), MIB_FEATURE_CMD_MAP(name) };
 								 //void dummy_mib_##name##_importer() { feature_map* a = &MIB_FEATURE_OBJ(name); }
 #define IMPORT_MIB_FEATURE(name) extern feature_map MIB_FEATURE_OBJ(name)
 
 #define DEFINE_FEATURE_MAP() static const feature_map* the_mib_features[] = 
 #define REGISTER_FEATURE_MAP() register_mib_features(the_mib_features, sizeof(the_mib_features)/sizeof(feature_map) )
+
+void register_mib_features( const feature_map** features, unsigned int count );
 
 #endif

--- a/momo_modules/shared/portable/mib/mib_feature_definition.h
+++ b/momo_modules/shared/portable/mib/mib_feature_definition.h
@@ -1,0 +1,8 @@
+#ifndef __mib_feature_definition_h
+#define __mib_feature_definition_h
+
+#define NO_MIB_FEATURE_EXTERNS
+#include "mib_features.h"
+#undef NO_MIB_FEATURE_EXTERNS
+
+#endif

--- a/momo_modules/shared/portable/mib/mib_features.h
+++ b/momo_modules/shared/portable/mib/mib_features.h
@@ -1,16 +1,27 @@
-#ifndef __mib_features_h
-#define __mib_features_h
+/*
+HERE THERE BE EXTERNS
+DO NOT include this in a file which defines a feature, include mib_feature_definition.h instead.
+*/
 
 #include "mib_feature.h"
+#ifndef NO_MIB_FEATURE_EXTERNS
+
 
 IMPORT_MIB_FEATURE(test);
 IMPORT_MIB_FEATURE(controller);
 IMPORT_MIB_FEATURE(programming);
+
+
+#endif
+#ifndef __mib_features_h
+#define __mib_features_h
+
 
 enum {
 	MIB_FEATURE_ID(test) = 0,
 	MIB_FEATURE_ID(controller) = 42,
 	MIB_FEATURE_ID(programming) = 255
 };
+
 
 #endif


### PR DESCRIPTION
Fixed the merge and re-applied my changes.

I still can't get my light to blink.  I tried it without my changes re-applied (so just dumping the conflicting stuff and using commands.h), as well as after going through and applying my changes but no dice.  I am using the old v1 module, through the power board, and using custom janky wires to plug in from the programming header to the momo bus header (my v2 seems to be busted, I never got it to work).  We can debug at the next meeting.

I'm not sure what the intention was for the PIC12 RPC command map, it looks incomplete?  In any case the stuff I changed was restricted mostly to mib_hal.c and included files, so it shouldn't be hard to either follow along with the pic12 or do that version completely separate.  Another discussion for tomorrow.
