### PR TITLE
PV Logging Module v1.0 and MIB12 Executive Able to Handle Paged Applications

### DIFF
--- a/config/build_settings.json
+++ b/config/build_settings.json
@@ -8,16 +8,19 @@
 		"default_settings" :
 		{
 			"executive_rom": [0, 1263],
-			"application_ram": [32, 96],
-			"executive_ram": [ [97,120], [160, 191] ],
-			"total_rom": 2048
+			"application_ram": [32, 106],
+			"executive_ram": [ [107,120], [160, 191] ],
+			"total_rom": 2048,
+			"flash_row_words": 16
 		},
 
 		"chip_settings" :
 		{
 			"16lf1847":
 			{
-				"executive_rom": [0, 1391],
+				"executive_rom": [0, 1407],
+				"flash_row_words": 32,
+				"total_rom": 4096,
 				"aliases": ["16F1847", "16LF1847"],
 				"xc8_target": "16F1847",
 				"xc8_define": "__PIC16LF1847__",
@@ -44,6 +47,7 @@
 		"includes" :
 		[
 			"../shared/pic12/src",
+			"../shared/pic12/src/peripheral",
 			"../shared/portable/core",
 			"../shared/portable/mib",
 			"../shared/portable/mib/slave",
@@ -60,7 +64,8 @@
 
 		"module_targets" :
 		{
-			"gsm_module": ["16lf1823"]
+			"gsm_module": ["16lf1823"],
+			"pv_module": ["16lf1847"]
 		},
 
 		"test" :

--- a/momo_modules/field_service_unit/src/debug/command_handlers.c
+++ b/momo_modules/field_service_unit/src/debug/command_handlers.c
@@ -270,8 +270,12 @@ static void rpc_callback(unsigned char status)
     }
     if ( bus_get_returnvalue_length() > 0 )
     {
-        if ( bus_get_returnvalue_length() == kIntSize ) { //TODO: MACRO
-            print_byte( plist_get_int16(0) ); // TODO: Typed return value
+        if ( bus_get_returnvalue_length() == kIntSize ) 
+        { 
+            char buff[10];
+            itoa_small(buff, 10, plist_get_int16(0));
+            print(buff); // TODO: Typed return value
+            print("\n");
         }
         else
         {

--- a/momo_modules/pic12_executive/src/appcode.h
+++ b/momo_modules/pic12_executive/src/appcode.h
@@ -12,6 +12,7 @@ const char app_task_vector @ kAppTaskAddress;
 #define call_app_init()			asm("call _app_init_vector")
 #define call_app_interrupt() 	asm("call _app_interrupt_vector")
 #define call_app_task()			asm("call _app_task_vector")
+#define reset_page()			asm("pagesel($)")
 
 #define sleep()  asm("sleep")
 

--- a/momo_modules/pic12_executive/src/bootloader.c
+++ b/momo_modules/pic12_executive/src/bootloader.c
@@ -38,8 +38,8 @@ void prepare_reflash(uint8 source)
 
 	set_flash_word(kFlashRowSize-2, source, kRetlwHighWord);
 	set_flash_word(kFlashRowSize-1, kReflashMagicNumber, kRetlwHighWord);
-	flash_erase_row(kNumFlashRows-1);
-	flash_write_row(kNumFlashRows-1); //Write the source and magic number into the memory
+	flash_erase_row(kMIBStructRow);
+	flash_write_row(kMIBStructRow); //Write the source and magic number into the memory
 }
 
 void get_half_row(uint8 offset)

--- a/momo_modules/pic12_executive/src/bootloader.c
+++ b/momo_modules/pic12_executive/src/bootloader.c
@@ -13,36 +13,36 @@
 #include "bus_master.h"
 #include <string.h>
 
-//The first 32 bytes of RAM in bank0 are used for reflashing.
+//The first N bytes of RAM in bank0 are used for reflashing, where N is 2*the flash row size for the uC.
 //they can also be used by the application since once we initiate a reflash
 //cycle, that application is gone.
 
-uint8 app_buffer[32] @ 0x20;
-uint8 boot_source @ 0x40;
-uint8 boot_count  @ 0x41;
-uint8 boot_id @ 0x42;
-uint8 i @ 0x43;
-uint8 tmp @ 0x44;
-uint8 invalid_row @ 0x45;
+uint8 app_buffer[32] @ 0x20; //ends at 0x60 if 64 bytes, (xc8 chokes if this is larger than 32 bytes, so just fake it.)
+uint8 boot_source @ 0x65;
+uint8 boot_count  @ 0x66;
+uint8 boot_id @ 0x67;
+uint8 i @ 0x68;
+uint8 tmp @ 0x69;
+uint8 invalid_row @ 0x6A;
 
 extern __persistent MIBExecutiveStatus status;
 
 void set_firmware_id(uint8 bucket)
 {
-	set_flash_word(13, bucket, kRetlwHighWord);
+	set_flash_word(kFlashRowSize-3, bucket, kRetlwHighWord);
 }
 
 void prepare_reflash(uint8 source)
 {
 	status.valid_app = 0;
 
-	set_flash_word(14, source, kRetlwHighWord);
-	set_flash_word(15, kReflashMagicNumber, kRetlwHighWord);
+	set_flash_word(kFlashRowSize-2, source, kRetlwHighWord);
+	set_flash_word(kFlashRowSize-1, kReflashMagicNumber, kRetlwHighWord);
 	flash_erase_row(kNumFlashRows-1);
 	flash_write_row(kNumFlashRows-1); //Write the source and magic number into the memory
 }
 
-uint8 get_half_row(uint8 offset)
+void get_half_row(uint8 offset)
 {
 	plist_set_int8(0, 0, boot_id);
 	plist_set_int8(0, 1, 0);
@@ -64,13 +64,15 @@ void enter_bootloader()
 	{
     	invalid_row = 0;
 
-    	get_half_row(0);
-    	get_half_row(16);
+    	for (tmp = 0; tmp < kBootloaderBufferSize; tmp += kMIBRequestSize)
+    		get_half_row(tmp);
 
 		flash_erase_row(boot_count);
 		//If there was a problem receiving the row, don't program it.  This is usually b/c
 		//the row is not defined in the application hex file, so it should be all 1's (unprogrammed)
 		if (!invalid_row)
+		{
 			flash_write_row(boot_count);
+		}
 	}
 }

--- a/momo_modules/pic12_executive/src/bootloader.h
+++ b/momo_modules/pic12_executive/src/bootloader.h
@@ -1,9 +1,8 @@
 #ifndef __bootloader_h__
 #define __bootloader_h__
 
-#define kNumFlashRows			128
-#define kFlashRowSize			16		//words
-#define kBootloaderBufferLoc	0x20	//bootloader uses first 32 bytes of ram in bank0 to cache flash row
+#include "bootloader_defs.h"
+
 #define kHighWordAddress		0x7FF
 #define kAppSourceAddress		0x7FE
 #define kRetlwHighWord			0b110100
@@ -17,7 +16,7 @@
 void 	set_firmware_id(uint8 bucket);
 void 	prepare_reflash(uint8 source);
 void 	enter_bootloader();
-uint8 	get_half_row(uint8 offset);
+void 	get_half_row(uint8 offset);
 
 typedef union
 {

--- a/momo_modules/pic12_executive/src/bootloader.h
+++ b/momo_modules/pic12_executive/src/bootloader.h
@@ -3,8 +3,6 @@
 
 #include "bootloader_defs.h"
 
-#define kHighWordAddress		0x7FF
-#define kAppSourceAddress		0x7FE
 #define kRetlwHighWord			0b110100
 
 #define set_flash_word(offset, low, high) 	{app_buffer[offset << 1] = low; app_buffer[(offset << 1) + 1] = high;}

--- a/momo_modules/pic12_executive/src/bootloader_defs.h
+++ b/momo_modules/pic12_executive/src/bootloader_defs.h
@@ -18,12 +18,13 @@
 #define kNumMIBRequests				(kBootloaderBufferSize/kMIBRequestSize)
 
 #define kNumFlashRows				(kFlashMemorySize / kFlashRowSize)
+#define kMIBStructRow				((2048 / kFlashRowSize) - 1)
 
 #if (kFlashRowSize != 16) && (kFlashRowSize != 32)
 #error Currently only 16 byte and 32 byte flash memory rows are supported
 #endif
 
-//Sanity check
+//Sanity checks to make sure we can support this chip type
 #if (kFlashMemorySize % kFlashRowSize) != 0
 #error The flash memory size must be a multiple of the flash row size
 #endif
@@ -34,6 +35,10 @@
 
 #if (kBootloaderBufferSize > 64)
 #error Cannot handler bootloader buffer sizes greater than 64 bytes yet.
+#endif
+
+#if (kNumFlashRows > 256)
+#error Cannot handle a chip with more than 256 rows.
 #endif
 
 #endif

--- a/momo_modules/pic12_executive/src/bootloader_defs.h
+++ b/momo_modules/pic12_executive/src/bootloader_defs.h
@@ -1,0 +1,39 @@
+#ifndef __bootloader_defs_h
+#define __bootloader_defs_h
+
+/*
+ * Define platform specific programming row sizes and other variables
+ * based on platform data passed from the MIB build system.  
+ *
+ * PIC12 processors are programmed by row where the row is composed of N
+ * words that are written to latches and then programmed at once.
+ * N depends on the memory size of the processor and is usually a power of 2.
+ * For the pic16f1823 and pic12f1822, N = 16, for the pic16lf1847, N = 32
+ */
+
+#define kBootloaderBufferSize 		(kFlashRowSize*2)
+#define kBootloaderBufferLoc		0x20	//bootloader uses first 2N bytes of ram in bank0 to cache flash row
+
+#define kMIBRequestSize				16
+#define kNumMIBRequests				(kBootloaderBufferSize/kMIBRequestSize)
+
+#define kNumFlashRows				(kFlashMemorySize / kFlashRowSize)
+
+#if (kFlashRowSize != 16) && (kFlashRowSize != 32)
+#error Currently only 16 byte and 32 byte flash memory rows are supported
+#endif
+
+//Sanity check
+#if (kFlashMemorySize % kFlashRowSize) != 0
+#error The flash memory size must be a multiple of the flash row size
+#endif
+
+#if (kBootloaderBufferSize % kMIBRequestSize) != 0
+#error The bootloader buffer size must be a multiple of the MIB request size
+#endif
+
+#if (kBootloaderBufferSize > 64)
+#error Cannot handler bootloader buffer sizes greater than 64 bytes yet.
+#endif
+
+#endif

--- a/momo_modules/pic12_executive/src/i2c_defines.h
+++ b/momo_modules/pic12_executive/src/i2c_defines.h
@@ -18,7 +18,7 @@
 #define SCLTRIS		TRISA1
 #elif  __PIC16LF1847__
 #define SDAPIN		RB1
-#define SCLPIN		RB3
+#define SCLPIN		RB4
 #define SDATRIS 	TRISB1
 #define SCLTRIS		TRISB4
 #else

--- a/momo_modules/pic12_executive/src/i2c_slave.c
+++ b/momo_modules/pic12_executive/src/i2c_slave.c
@@ -21,7 +21,6 @@ void i2c_slave_setidle()
 	i2c_release_clock();
 }
 
-//#pragma interrupt_level 1
 void i2c_slave_interrupt()
 {	
 	if (i2c_address_received())

--- a/momo_modules/pic12_executive/src/main.c
+++ b/momo_modules/pic12_executive/src/main.c
@@ -48,14 +48,10 @@ void interrupt service_isr() {
 }
 
 void main() 
-{    
+{   
     initialize();
 
-    TRISA2 = !TRISA2;
-
     restore_status();
-
-    TRISA2 = !TRISA2;
 
     if (status.bootload_mode)
     {
@@ -107,7 +103,11 @@ void initialize()
     ANSELC = 0;
     #endif
 
-    RA2 = 0;
+    #ifdef __PIC16LF1847__
+    TRISB = 0xff;
+    ANSELB = 0;
+    LATA7 = 0;
+    #endif
 
     /* Set all PORTA pins to be digital I/O (instead of analog input). */
     ANSELA = 0;
@@ -133,6 +133,7 @@ void restore_status()
         
         //Wait 1 second to make the controller had time to power on
         //in case this is a power on reset
+
         wdt_settimeout(k1SecondTimeout);
         wdt_enable();
         sleep();
@@ -141,6 +142,7 @@ void restore_status()
         bus_init(kMIBUnenumeratedAddress);
 
         address = register_module();
+
 
         if (address > 0)
         {

--- a/momo_modules/pic12_executive/src/main.c
+++ b/momo_modules/pic12_executive/src/main.c
@@ -41,6 +41,7 @@ void interrupt service_isr() {
         wdt_settimeout(k1SecondTimeout);
         wdt_enable(); 
         call_app_interrupt();
+        reset_page();
         wdt_disable();
     }
 
@@ -66,6 +67,7 @@ void main()
         wdt_settimeout(k1SecondTimeout);
         wdt_enable();
         call_app_init();
+        reset_page();
         wdt_disable();
 
         while(1)
@@ -73,6 +75,7 @@ void main()
             wdt_settimeout(k1SecondTimeout);
             wdt_enable();
             call_app_task();
+            reset_page();
             wdt_disable();
 
             sleep();

--- a/momo_modules/pic12_executive/src/mib/mib_api.as
+++ b/momo_modules/pic12_executive/src/mib/mib_api.as
@@ -9,7 +9,8 @@ PSECT mibapi,abs,local,class=CODE,delta=2
 global _main
 
 ;Use the final high words of the mib_executive rom for api callbacks
-org (kFirstApplicationRow-1)*16 + 14
+;mib api lives in the last 16 bytes before the application
+org (kFirstApplicationRow)*kFlashRowSize - 16 + 14
 ;dw 2
 BEGINREGION mib12_api
 	goto _main

--- a/momo_modules/pic12_executive/src/mib/mib_hal_asm.as
+++ b/momo_modules/pic12_executive/src/mib/mib_hal_asm.as
@@ -96,15 +96,23 @@ BEGINFUNCTION _call_handler
 	GOTO _exec_call_cmd
 	call_app:
 	movf FSR1L,w
-	GOTO 0x7FE				;branch to the goto in high memory that redirects to the application code's mib callback table
+
+	call 0x7FE				;branch to the goto in high memory that redirects to the application code's mib callback table
+	pagesel($)
+	return 
+
 ENDFUNCTION _call_handler
 
 BEGINFUNCTION _get_feature
-	GOTO 0x7FB
+	call 0x7FB
+	pagesel($)
+	return
 ENDFUNCTION _get_feature
 
 BEGINFUNCTION _get_command
-	GOTO 0x7FC
+	call 0x7FC
+	pagesel($)
+	return 
 ENDFUNCTION _get_command
 
 BEGINFUNCTION _get_param_spec
@@ -116,9 +124,12 @@ BEGINFUNCTION _get_param_spec
 	GOTO call_spec
 	movf FSR1L,w
 	GOTO _exec_get_spec
+	
 	call_spec:
 	movf FSR1L,w
-	GOTO 0x7FD
+	call 0x7FD
+	pagesel($)
+	return
 ENDFUNCTION _get_param_spec
 
 ;Given a word offset in the mib module definition block

--- a/momo_modules/pic12_executive/src/mib/mib_hal_asm.as
+++ b/momo_modules/pic12_executive/src/mib/mib_hal_asm.as
@@ -152,7 +152,9 @@ BEGINFUNCTION _get_magic
 ENDFUNCTION _get_magic
 
 BEGINFUNCTION _get_num_features
-	GOTO 0x7FA
+	call 0x7FA
+	pagesel($)
+	return
 ENDFUNCTION _get_num_features
 
 BEGINFUNCTION _plist_int_count

--- a/momo_modules/pic12_executive/src/mib/slave/commands/executive.c
+++ b/momo_modules/pic12_executive/src/mib/slave/commands/executive.c
@@ -4,8 +4,8 @@
 
 void exec_prepare_reflash()
 {
-	set_firmware_id(plist_get_int8(1, 0));
-	prepare_reflash(plist_get_int8(0, 0));
+	set_firmware_id(plist_get_int8(2));
+	prepare_reflash(plist_get_int8(0));
 	bus_slave_setreturn(pack_return_status(0,0));
 }
 

--- a/momo_modules/pic12_executive/test/test_boot_address.as
+++ b/momo_modules/pic12_executive/test/test_boot_address.as
@@ -1,0 +1,29 @@
+;Name: test_boot_address
+;Type: executive
+;Description: Test to ensure that the row address of flash memory is calculated
+correctly
+
+#include <xc.inc>
+#include "asm_macros.inc"
+#include "symbols.h"
+#include "test_macros.inc"
+#include "test_asserts.inc"
+
+global _begin_tests
+global _loghex, _finish_tests, _assertv
+global _mib_buffer, _mib_packet
+
+PSECT text_unittest,local,class=CODE,delta=2
+BEGINFUNCTION _begin_tests
+	movlb 0
+	movlw 44
+	movwf 0x66		;boot count
+	asm_call_load_boot_address()
+	movlb 1
+	movf  BANKMASK(_mib_buffer+2),w
+	assertlw (kFlashRowSize*44*2) & 0x00FF
+	movf BANKMASK(_mib_buffer+3),w
+	assertlw ((kFlashRowSize*44*2) & 0xFF00) >> 8
+
+	return
+ENDFUNCTION _begin_tests

--- a/momo_modules/pic12_executive/test/test_call_handler.as
+++ b/momo_modules/pic12_executive/test/test_call_handler.as
@@ -1,0 +1,31 @@
+;Name: test_call_handler
+;Targets: all
+;Type: executive
+;Description: Test to ensure that the find_handler function works  
+
+#include <xc.inc>
+#include "asm_macros.inc"
+#include "symbols.h"
+#include "test_macros.inc"
+#include "test_asserts.inc"
+
+global _begin_tests
+global _loghex, _finish_tests, _assertv
+global _mib_buffer, _mib_packet
+
+PSECT text_unittest,local,class=CODE,delta=2
+BEGINFUNCTION _begin_tests
+	;Check for a mib executive endpoint that should exist
+	load_packet mib_test
+	asm_call_find_handler()
+	assertlw 2
+	movlw 2
+	asm_call_call_handler()
+
+	return
+ENDFUNCTION _begin_tests
+
+
+
+define_packet mib_test, 1, 2, 3
+db 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 ,14, 15, 16, 17, 18, 19, 20

--- a/momo_modules/pic12_executive/test/test_flash_write.as
+++ b/momo_modules/pic12_executive/test/test_flash_write.as
@@ -1,0 +1,23 @@
+;Name: test_flash_write
+;Type: executive
+;Description: Test to ensure that flash_write_row works correctly
+
+#include <xc.inc>
+#include "asm_macros.inc"
+#include "symbols.h"
+#include "test_macros.inc"
+#include "test_asserts.inc"
+
+global _begin_tests
+global _loghex, _finish_tests, _assertv
+global _mib_buffer, _mib_packet
+
+PSECT text_unittest,local,class=CODE,delta=2
+BEGINFUNCTION _begin_tests
+	movlb 0
+	movlw 44
+	movwf 0x66		;boot count
+	asm_call_flash_write_row()
+	
+	return
+ENDFUNCTION _begin_tests

--- a/momo_modules/pv_module/src/SConscript
+++ b/momo_modules/pv_module/src/SConscript
@@ -4,20 +4,17 @@ incs = []
 incs.append('.')
 incs.append('src')
 incs.append('src/mib')
-incs.append('../shared/pic12/src')
-incs.append('../shared/portable/core')
-incs.append('../shared/portable/mib')
-incs.append('../shared/portable/mib/slave')
-incs.append('../shared/portable/mib/master')
-incs.append('../shared/portable/util')
+
 
 Import('env')
-env['INCLUDE'] = incs
+env['INCLUDE'].extend(incs)
 env['NO_STARTUP'] = True
 
 asm_sources = ['app_startup.as', 'mib/command_map.as', 'mib/mib12_api.as']
+peri = ['../../../shared/pic12/src/peripheral/adc.c', '../../../shared/pic12/src/peripheral/spi2.c']
 
-srcfiles = asm_sources + Glob('./*.c')									
+srcfiles = asm_sources + Glob('./*.c') + peri
+
 
 target = env.xc8('mib12_app_module.hex', srcfiles)
 symtab = env.build_symbols(['mib12_app_module_symbols.h', 'mib12_app_module_symbols.stb'],['mib12_app_module.sym'])

--- a/momo_modules/pv_module/src/app_main.c
+++ b/momo_modules/pv_module/src/app_main.c
@@ -2,10 +2,31 @@
 
 #include "platform.h"
 #include "watchdog.h"
+#include "pv_defines.h"
+#include "port.h"
+#include "sample.h"
+#include "sdcard.h"
+#include "mib12_api.h"
+#include "fat32.h"
+#include "log.h"
+#include "watchdog.h"
+
+extern uint8 filename[11];
+extern uint8 sector[512];
 
 void task(void)
 {
+	wdt_disable();
 
+	while(1)
+	{
+		WDTCON = k1SecondTimeout;
+		wdt_enable();
+		asm("sleep");
+		wdt_disable();
+
+		log_logsamples();
+	}
 }
 
 void interrupt_handler(void)
@@ -15,10 +36,80 @@ void interrupt_handler(void)
 
 void initialize(void)
 {
+	wdt_disable();
+
+	PIN_DIR(VOLT1, INPUT);
+	PIN_TYPE(VOLT1, ANALOG);
+
+	PIN_DIR(VOLT2, INPUT);
+	PIN_TYPE(VOLT2, ANALOG);
 	
+	PIN_DIR(VOLT3, INPUT);
+	PIN_TYPE(VOLT3, ANALOG);
+	
+	PIN_DIR(CURR1, INPUT);
+	PIN_TYPE(CURR1, ANALOG);
+
+	sd_pins_idle();
+
+	log_init();
 }
 
 void main()
 {
-	
+}
+
+void power_sdcard()
+{
+	/*if(mib_buffer[0] == 0)
+		sd_power_off();
+	else
+	{
+		sd_power_on();
+		f32_openvol();
+
+		filename[0] = 'L';
+		filename[1] = 'O';
+		filename[2] = 'G';
+		filename[3] = ' ';
+		filename[4] = ' ';
+		filename[5] = ' ';
+		filename[6] = ' ';
+		filename[7] = ' ';
+		filename[8] = 'B';
+		filename[9] = 'I';
+		filename[10] = 'N';
+
+		mib_buffer[1] = 0;
+
+		f32_findfile();
+		
+		if (f32_seek(51) != kSDNoError)
+			mib_buffer[0] = 1;
+		else
+		{
+			uint8 i=0;
+			sector[i++] = 0xA0;
+			sector[i++] = 0xB0;
+			sector[i++] = 0xC0;
+			sector[i++] = 0xD0;
+
+			mib_buffer[0] = 2;
+			f32_sync();
+		}
+
+
+		bus_slave_setreturn(pack_return_status(0, 2));
+		return;
+	}*/
+
+	bus_slave_setreturn(pack_return_status(0, 0));
+}
+
+void check_sdcard()
+{
+	mib_buffer[0] = sd_check_inserted();
+	mib_buffer[1] = 0;
+
+	bus_slave_setreturn(pack_return_status(0, 2));
 }

--- a/momo_modules/pv_module/src/app_startup.as
+++ b/momo_modules/pv_module/src/app_startup.as
@@ -2,14 +2,23 @@
 
 #include <xc.inc>
 
+jumpm MACRO name,dest
+name:
+	movlp dest >> 8
+	goto  dest && ((1<<11) - 1)
+ENDM
 
-global _main, _task,_initialize,_interrupt_handler,start,intlevel1
+global _task,_initialize,_interrupt_handler,start,intlevel1
 
 PSECT reset_vec,global,class=CODE,delta=2
 start:
-goto _initialize
-goto _interrupt_handler
-goto _task
+goto doinit
+goto dointer
+goto dotask
+
+jumpm doinit,_initialize
+jumpm dointer,_interrupt_handler
+jumpm dotask,_task
 
 intlevel1:
 

--- a/momo_modules/pv_module/src/fat32.c
+++ b/momo_modules/pv_module/src/fat32.c
@@ -1,0 +1,175 @@
+//fat32.c
+
+#include "fat32.h"
+#include "sdcard.h"
+
+FAT32VolumeInfo vol;
+uint8 			filename[11];
+
+extern uint8 sector[512];
+
+static uint32_t f32_nextcluster(uint32_t curr);
+
+SDErrorCode f32_openvol()
+{
+	uint32_t part_start;
+	uint8	 part_code;
+
+	//Initialize file state
+	vol.open_flags = kFileInvalid;
+	vol.curr_sector = 0xFFFFFFFF;
+
+	//Read in the MBR
+	if (sd_read(0) != kSDNoError)
+		return kSDIOError;
+
+	//Make sure the MBR is valid
+	if (sector[510] != 0x55 || sector[511] != 0xAA)
+		return kSDInvalidMBR;
+
+	//Make sure partition 1 is a FAT32 partition
+	part_code = sector[kPartition1TypeOffset];
+	if (part_code != 0x0B && part_code != 0x0C)
+		return kSDInvalidPartition;
+
+	part_start = *(uint32_t *)(sector + kPartition1LBAOffset);
+	return f32_openpart(part_start);
+}
+
+SDErrorCode f32_openpart(uint32_t part_start)
+{
+	uint16_t reserved_sectors;
+	uint32_t sectors_per_fat;
+
+	if (sd_read(part_start) != kSDNoError)
+		return kSDIOError;
+
+	if (sector[0x10] != 2)
+		return kSDInvalidPartition;
+
+	reserved_sectors = *(uint16_t *)(sector + 0x0E);
+	sectors_per_fat = *(uint32_t *)(sector + 0x24);
+
+	vol.fat_start =  part_start + reserved_sectors;
+	vol.cluster_start = vol.fat_start + (sectors_per_fat << 1); //num_fats * sectors_per_fat
+	vol.cluster_size = sector[0x0D];
+	vol.rootdir_cluster = *(uint32_t *)(sector + 0x2C);
+
+	return kSDNoError;
+}
+
+uint32_t f32_clustertolba(uint32_t cluster)
+{
+	return vol.cluster_start + (cluster - 2)*vol.cluster_size;
+}
+
+SDErrorCode f32_loadsector(uint32_t sector)
+{
+	SDErrorCode code;
+	if (sector == vol.curr_sector)
+		return kSDNoError;
+
+	
+	code = sd_read(sector);
+	if (code != kSDNoError)
+	{
+		vol.curr_sector = 0xFFFFFFFF;
+		return code;
+	}
+
+	vol.curr_sector = sector;
+	return kSDNoError;
+}
+
+SDErrorCode f32_sync()
+{
+	if (vol.curr_sector == 0xFFFFFFFF)
+		return kSDInvalidSector;
+
+	return sd_write(vol.curr_sector);
+}
+
+SDErrorCode f32_seek(uint32_t sector)
+{
+	uint32_t cluster_idx;
+	uint32_t curr_cluster = vol.open_root_cluster;
+	uint8_t  sector_offset;
+
+	if (vol.open_flags == kFileInvalid)
+		return kSDFileNotOpenError;
+
+	vol.open_sector = sector;
+
+	cluster_idx = sector / vol.cluster_size;	//FIXME: can optimize this since vol.cluster_size is a power of 2 always
+
+	while (cluster_idx-- > 0)
+		curr_cluster = f32_nextcluster(curr_cluster);
+
+	sector_offset = sector & (vol.cluster_size - 1);
+
+	sector = f32_clustertolba(curr_cluster) + sector_offset;
+
+
+	return f32_loadsector(sector);
+}
+
+static uint32_t f32_nextcluster(uint32_t curr)
+{
+	uint32_t fat_sector = vol.fat_start + (curr & kFATSectorMask);
+	uint16_t  fat_index  = curr & kFATEntryMask;
+
+	fat_index *= 4;
+
+	f32_loadsector(fat_sector);
+	
+	return *(uint32_t*)(sector + fat_index);
+}
+
+SDErrorCode f32_findfile()
+{
+	uint32_t root_start = f32_clustertolba(vol.rootdir_cluster);
+	uint8 	j, match;
+	uint16  i;
+
+	vol.open_flags = kFileInvalid;
+
+	if (f32_loadsector(root_start) != kSDNoError)
+		return kSDIOError;
+
+	for (i=0; i<512; i+=32)
+	{
+		FAT32Entry *entry = (FAT32Entry *)(sector + i);
+
+		//0xE5 indicated unused entry
+		if (entry->name[0] == 0xE5)
+			continue;
+
+		//0x00 indicates end of directory
+		if (entry->name[0] == 0x00)
+			return kSDFileNotFoundError;
+
+		match = 1;
+
+		for (j=0; j<11; ++j)
+		{
+			if (entry->name[j] != filename[j])
+			{
+				match = 0;
+				break;
+			}
+		}
+
+		if (match == 1)
+		{
+			vol.open_root_cluster = entry->cluster_high;
+			vol.open_root_cluster <<= 16;
+			vol.open_root_cluster |= entry->cluster_low;
+
+			vol.open_flags = kFileFound;
+
+			return kSDNoError;
+		}
+	}
+
+	return kSDFileNotFoundError;
+}

--- a/momo_modules/pv_module/src/fat32.h
+++ b/momo_modules/pv_module/src/fat32.h
@@ -36,6 +36,7 @@ typedef struct
 	uint8 	 open_flags;
 	uint32_t open_root_cluster;
 	uint32_t open_sector;
+	uint32_t open_size;
 } FAT32VolumeInfo;
 
 typedef struct

--- a/momo_modules/pv_module/src/fat32.h
+++ b/momo_modules/pv_module/src/fat32.h
@@ -1,0 +1,60 @@
+/*fat32.h
+ * A very simple fat32 driver with support for 1 directory and a fixed set of files
+ * that are preallocated.
+ */
+
+#ifndef __fat32_h__
+#define __fat32_h__
+
+#include "platform.h"
+#include "sdcard.h"
+#include <stdint.h>
+
+#define kBootCodeSize			446
+#define kPartition1TypeOffset	(kBootCodeSize + 4)
+#define kPartition1LBAOffset	(kBootCodeSize + 8)
+#define kFATEntryMask			(0b1111111)
+#define kFATSectorMask			(~kFATEntryMask)
+
+enum
+{
+	kFileFound = 0,
+	kFileOpen = 1,
+	kFileInvalid
+};
+
+typedef struct
+{
+	uint32_t fat_start;
+	uint32_t cluster_start;
+	uint32_t rootdir_cluster;
+	uint8_t  cluster_size;
+
+	uint32_t curr_sector;
+
+	uint8 	 open_name[11];
+	uint8 	 open_flags;
+	uint32_t open_root_cluster;
+	uint32_t open_sector;
+} FAT32VolumeInfo;
+
+typedef struct
+{
+	uint8  		name[11];
+	uint8 		attrib;
+	uint8 		reserved1[8];
+	uint16_t	cluster_high;
+	uint8 		reserved2[4];
+	uint16_t 	cluster_low;
+	uint32_t	size;
+} FAT32Entry;
+
+SDErrorCode f32_openvol();
+SDErrorCode f32_openpart(uint32_t part_start);
+SDErrorCode	f32_findfile();
+SDErrorCode f32_loadsector(uint32_t sector);
+SDErrorCode f32_seek(uint32_t sector);
+SDErrorCode f32_sync();
+
+uint32_t 	f32_clustertolba(uint32_t cluster);
+#endif

--- a/momo_modules/pv_module/src/log.c
+++ b/momo_modules/pv_module/src/log.c
@@ -3,23 +3,83 @@
 
 uint32_t sector_index;
 uint16_t sector_off;
+uint8	 log_interval;
 
 extern uint8 	sector[512];
 extern uint8 	filename[11];
 extern unsigned int adc_result;
 
-static void log_nextsector();
-static void log_loadsector();
+static uint8 log_nextsector();
+static uint8 log_loadsector();
+static void log_readtoc();
 
-void log_init()
+uint8 log_init()
 {
-	sector_index = 0;
-	sector_off = 0;
+	if (sd_check_inserted() != 1)
+	{
+		sector_index = 1;
+		sector_off = 0;
+		log_interval = kDefaultLogInterval;
+		return 0;
+	}
 
-	log_loadsector();
+	//Otherwise, figure out where we are supposed to start writing given the TOC
+	log_readtoc();
+	if (log_loadsector() == 1)
+		return 0;
+
+	return 1;
 }
 
-void log_logsamples()
+static void log_updatetoc()
+{
+	uint16_t off = 0;
+	uint32_t next_sec = sector_index;
+
+	sector_index = 0;
+	log_loadsector();
+
+	sector[off++] = 0x12;
+	sector[off++] = 0x34;
+	sector[off++] = 0x56;
+	sector[off++] = 0x78;
+	sector[off++] = next_sec & 0xFF;
+	sector[off++] = (next_sec >> 8) & 0xFF;
+	sector[off++] = (next_sec >> 16) & 0xFF;
+	sector[off++] = (next_sec >> 24) & 0xFF;
+	sector[off++] = log_interval;
+
+	sd_power_on();
+	f32_sync();
+	sd_power_off();
+
+	sector_index = next_sec;
+	sector_off = 0;
+}
+
+static void log_readtoc()
+{
+	sector_index = 0;
+	log_loadsector();
+
+	//Check if we have a valid TOC sector 
+	if ((*(uint32_t*)(sector)) == 0x78563412)
+	{
+		sector_index = (*(uint32_t*)(sector+4));
+		log_interval = (*(uint8*)(sector+8));
+		sector_off = 0;
+	}
+	else
+	{
+		sector_index = 1;
+		sector_off = 0;
+		log_interval = kDefaultLogInterval;
+
+		log_updatetoc();
+	}
+}
+
+uint8 log_logsamples()
 {
 	sector[sector_off++] = 0xAA;
 	sector[sector_off++] = 0xBB;
@@ -50,16 +110,67 @@ void log_logsamples()
 	sector[sector_off++] = (adc_result >> 8) & 0xFF;
 
 	if (sector_off >= 512)
-		log_nextsector();
+		return log_nextsector();
+
+	return 0;
 }
 
-static void log_loadsector()
+void log_setinterval()
+{
+	if (log_interval > kLogInterval256s)
+		log_interval = kDefaultLogInterval;
+
+	switch (log_interval)
+	{
+		case kLogInterval1s:
+		WDTCON = kWatchdog1s;
+		break;
+
+		case kLogInterval2s:
+		WDTCON = kWatchdog2s;
+		break;
+
+		case kLogInterval4s:
+		WDTCON = kWatchdog4s;
+		break;
+		
+		case kLogInterval8s:
+		WDTCON = kWatchdog8s;
+		break;
+		
+		case kLogInterval16s:
+		WDTCON = kWatchdog16s;
+		break;
+
+		case kLogInterval32s:
+		WDTCON = kWatchdog32s;
+		break;
+		
+		case kLogInterval64s:
+		WDTCON = kWatchdog64s;
+		break;
+
+		case kLogInterval128s:
+		WDTCON = kWatchdog128s;
+		break;
+		
+		case kLogInterval256s:
+		WDTCON = kWatchdog256s;
+		break;
+	}
+}
+
+static uint8 log_loadsector()
 {
 	if (sd_check_inserted() != 1)
-		return;
+		return 1;
 
 	sd_power_on();
-	f32_openvol();
+	if (f32_openvol() != kSDNoError)
+	{
+		sd_power_off();
+		return 1;
+	}
 
 	filename[0] = 'L';
 	filename[1] = 'O';
@@ -73,29 +184,45 @@ static void log_loadsector()
 	filename[9] = 'I';
 	filename[10] = 'N';
 
-	f32_findfile();
-	f32_seek(sector_index);
+	if (f32_findfile() != kSDNoError)
+	{
+		sd_power_off();
+		return 1;
+	}
+
+	//If we are at the end of the file, maybe try to add another cluster?
+	if (f32_seek(sector_index) == kSDEOFError)
+	{
+		sd_power_off();
+		return 1;
+	}
 
 	sd_power_off();
+	return 0;
 }
 
-static void log_nextsector()
+static uint8 log_nextsector()
 {
+	uint8 err;
 	if (sd_check_inserted() != 1)
 	{
 		sector_off = 0;
-		return;
+		return 1;
 	}
 
 	sd_power_on();
-	f32_sync();
+	err = f32_sync();
 	sd_power_off();
+
+	if (err != kSDNoError)
+		return 1;
 
 	++sector_index;
 	sector_off = 0;
 
-	log_loadsector();
+	log_updatetoc();
 
+	return log_loadsector();
 }
 
 void log_getoffset()

--- a/momo_modules/pv_module/src/log.c
+++ b/momo_modules/pv_module/src/log.c
@@ -1,0 +1,115 @@
+#include "log.h"
+#include "mib12_api.h"
+
+uint32_t sector_index;
+uint16_t sector_off;
+
+extern uint8 	sector[512];
+extern uint8 	filename[11];
+extern unsigned int adc_result;
+
+static void log_nextsector();
+static void log_loadsector();
+
+void log_init()
+{
+	sector_index = 0;
+	sector_off = 0;
+
+	log_loadsector();
+}
+
+void log_logsamples()
+{
+	sector[sector_off++] = 0xAA;
+	sector[sector_off++] = 0xBB;
+
+	sector[sector_off++] = 0xCC;
+	sector[sector_off++] = 0xDD;
+
+	sector[sector_off++] = 0xEE;
+	sector[sector_off++] = 0xFF;
+
+	sector[sector_off++] = 0x55;
+	sector[sector_off++] = 0x99;
+
+	sample_v1();
+	sector[sector_off++] = (1 << 7) | (adc_result & 0xFF);
+	sector[sector_off++] = (adc_result >> 8) & 0xFF;
+
+	sample_v2();
+	sector[sector_off++] = adc_result & 0xFF;
+	sector[sector_off++] = (adc_result >> 8) & 0xFF;
+
+	sample_v3();
+	sector[sector_off++] = adc_result & 0xFF;
+	sector[sector_off++] = (adc_result >> 8) & 0xFF;
+
+	sample_i1();
+	sector[sector_off++] = adc_result & 0xFF;
+	sector[sector_off++] = (adc_result >> 8) & 0xFF;
+
+	if (sector_off >= 512)
+		log_nextsector();
+}
+
+static void log_loadsector()
+{
+	if (sd_check_inserted() != 1)
+		return;
+
+	sd_power_on();
+	f32_openvol();
+
+	filename[0] = 'L';
+	filename[1] = 'O';
+	filename[2] = 'G';
+	filename[3] = ' ';
+	filename[4] = ' ';
+	filename[5] = ' ';
+	filename[6] = ' ';
+	filename[7] = ' ';
+	filename[8] = 'B';
+	filename[9] = 'I';
+	filename[10] = 'N';
+
+	f32_findfile();
+	f32_seek(sector_index);
+
+	sd_power_off();
+}
+
+static void log_nextsector()
+{
+	if (sd_check_inserted() != 1)
+	{
+		sector_off = 0;
+		return;
+	}
+
+	sd_power_on();
+	f32_sync();
+	sd_power_off();
+
+	++sector_index;
+	sector_off = 0;
+
+	log_loadsector();
+
+}
+
+void log_getoffset()
+{
+	mib_buffer[0] = sector_off & 0xFF;
+	mib_buffer[1] = (sector_off >> 8) & 0xFF;
+
+	bus_slave_setreturn(pack_return_status(0, 2));
+}
+
+void log_getsector()
+{
+	mib_buffer[0] = sector_index & 0xFF;
+	mib_buffer[1] = (sector_index >> 8) & 0xFF;
+
+	bus_slave_setreturn(pack_return_status(0, 2));
+}

--- a/momo_modules/pv_module/src/log.h
+++ b/momo_modules/pv_module/src/log.h
@@ -5,9 +5,38 @@
 #include "fat32.h"
 #include "sdcard.h"
 
-void log_init();
-void log_logsamples();
+#define kDefaultLogInterval	kLogInterval64s
+
+enum
+{
+	kLogInterval1s = 0,
+	kLogInterval2s = 1,
+	kLogInterval4s = 2,
+	kLogInterval8s = 3,
+	kLogInterval16s = 4,
+	kLogInterval32s = 5,
+	kLogInterval64s = 6,
+	kLogInterval128s = 7,
+	kLogInterval256s = 8
+};
+
+enum
+{
+	kWatchdog1s   = 0b010100,
+	kWatchdog2s   = 0b010110,
+	kWatchdog4s   = 0b011000,
+	kWatchdog8s   = 0b011010,
+	kWatchdog16s  = 0b011100,
+	kWatchdog32s  = 0b011110,
+	kWatchdog64s  = 0b100000,
+	kWatchdog128s = 0b100001,
+	kWatchdog256s = 0b100100
+};
+
+uint8 log_init();
+uint8 log_logsamples();
 void log_getoffset();
 void log_getsector();
+void log_setinterval();
 
 #endif

--- a/momo_modules/pv_module/src/log.h
+++ b/momo_modules/pv_module/src/log.h
@@ -1,0 +1,13 @@
+#ifndef __log_h__
+#define __log_h__
+
+#include "sample.h"
+#include "fat32.h"
+#include "sdcard.h"
+
+void log_init();
+void log_logsamples();
+void log_getoffset();
+void log_getsector();
+
+#endif

--- a/momo_modules/pv_module/src/mib/command_map.as
+++ b/momo_modules/pv_module/src/mib/command_map.as
@@ -12,7 +12,7 @@ name:
 	
 ENDM
 
-global _sample_v1, _sample_i1,_log_getoffset,_log_getsector
+global _sample_v1, _sample_i1,_log_getoffset,_log_getsector,_open_size
 
 ;Define the number of supported features and where to store the callback table pointer
 ;in ROM
@@ -32,14 +32,14 @@ global _sample_v1, _sample_i1,_log_getoffset,_log_getsector
 
 PSECT mibstructs,local,class=CONST,delta=2
 jumptable:
-jumpm samplev,_sample_v1
+jumpm checksize,_open_size
 jumpm samplei,_sample_i1
 jumpm checkoff,_log_getoffset
 jumpm checksect,_log_getsector
 
 mibhandlers:
 BRW
-goto samplev
+goto checksize
 goto samplei
 goto checkoff
 goto checksect

--- a/momo_modules/pv_module/src/mib/command_map.as
+++ b/momo_modules/pv_module/src/mib/command_map.as
@@ -5,9 +5,18 @@
 #include "constants.h"
 #include "definitions.h"
 
+jumpm MACRO name,dest
+name:
+	pagesel(dest)
+	goto  dest && ((1<<11) - 1)
+	
+ENDM
+
+global _sample_v1, _sample_i1,_log_getoffset,_log_getsector
+
 ;Define the number of supported features and where to store the callback table pointer
 ;in ROM
-#define kNumFeatures 			0
+#define kNumFeatures 			1
 
 ;Define ways to create parameter specs simply
 #define plist_param_n(n, type) 					((type & 0x01) << (n+3))
@@ -21,11 +30,45 @@
 #define plist_define2(type1, type2)				plist_define(2, plist_2params(type1, type2))
 #define plist_define3(type1, type2, type3)		plist_define(3, plist_3params(type1, type2, type3))
 
+PSECT mibstructs,local,class=CONST,delta=2
+jumptable:
+jumpm samplev,_sample_v1
+jumpm samplei,_sample_i1
+jumpm checkoff,_log_getoffset
+jumpm checksect,_log_getsector
+
+mibhandlers:
+BRW
+goto samplev
+goto samplei
+goto checkoff
+goto checksect
+
+mibfeatures:
+BRW
+RETLW 	20
+
+mibcommands:
+BRW
+RETLW 0
+RETLW 4
+
+mibspecs:
+BRW
+RETLW 0
+RETLW 1<<5
+RETLW 0
+RETLW 0
+
 PSECT mibmap,abs,ovrld,local,class=CODE,delta=2
 
 ;High memory command structure for processing mib slave endpoints
 
-org 	kMIBEndpointAddress
+org 	kMIBEndpointAddress - 8
+jumpm mf,mibfeatures
+jumpm mc,mibcommands
+jumpm ms,mibspecs
+jumpm mh,mibhandlers
 
 ;Module Name (must be exactly 8 characters long)
 db 		ModuleName
@@ -37,26 +80,8 @@ retlw 	ModuleFlags
 
 ;MIB endpoint information
 retlw 	kNumFeatures
-goto 	mibfeatures
-goto 	mibcommands
-goto 	mibspecs
-goto 	mibhandlers
+goto 	mf
+goto 	mc
+goto 	ms
+goto 	mh
 retlw	kMIBMagicNumber
-
-PSECT mibstructs,local,class=CONST,delta=2
-
-mibhandlers:
-BRW
-
-mibfeatures:
-BRW
-RETLW 	0
-
-mibcommands:
-BRW
-RETLW 0
-RETLW 0
-
-mibspecs:
-BRW
-RETLW 0

--- a/momo_modules/pv_module/src/mib/mib12_api.as
+++ b/momo_modules/pv_module/src/mib/mib12_api.as
@@ -12,10 +12,10 @@ global _bus_master_rpc_sync, _bus_slave_setreturn
 global _mib_buffer,_mib_packet
 
 ;API Functions
-_bus_master_rpc_sync equ (kFirstApplicationRow-1)*16 + 14
-_bus_slave_setreturn equ (kFirstApplicationRow-1)*16 + 15
+_bus_master_rpc_sync equ (kFirstApplicationRow)*kFlashRowSize - 2
+_bus_slave_setreturn equ (kFirstApplicationRow)*kFlashRowSize - 1
 
 ;API Data Structure
 psect mibstate class=BANK1,abs
-_mib_buffer equ 0xA0
-_mib_packet equ 0xB4
+_mib_buffer equ 0xA2
+_mib_packet equ 0xB6

--- a/momo_modules/pv_module/src/pv_defines.h
+++ b/momo_modules/pv_module/src/pv_defines.h
@@ -1,0 +1,16 @@
+#ifndef __pv_defines_h__
+#define __pv_defines_h__
+
+#define VOLT1		A4
+#define VOLT2		A3
+#define VOLT3		A2
+#define CURR1		B3
+
+#define SDPOW		A6
+#define SDSEL		A1
+#define SDO			A0
+#define SDI			B2
+#define SDDET		B0
+#define SDCLK		B5
+
+#endif

--- a/momo_modules/pv_module/src/sample.c
+++ b/momo_modules/pv_module/src/sample.c
@@ -1,0 +1,50 @@
+
+#include "sample.h"
+#include "mib12_api.h"
+#include "adc.h"
+
+#define _XTAL_FREQ			4000000
+
+void sample_v1()
+{
+	adc_configure(ADCBuildConfig(kADCRightJustified, kFRC, kADCVSSNegRef, kADCVDDPosRef));
+	adc_setenabled(1);
+	adc_setchannel(kADCChannelAN4);
+
+	adc_average(10);
+
+	adc_setenabled(0);
+}
+
+void sample_v2()
+{
+	adc_configure(ADCBuildConfig(kADCRightJustified, kFRC, kADCVSSNegRef, kADCVDDPosRef));
+	adc_setenabled(1);
+	adc_setchannel(kADCChannelAN3);
+
+	adc_average(10);
+
+	adc_setenabled(0);
+}
+
+void sample_v3()
+{
+	adc_configure(ADCBuildConfig(kADCRightJustified, kFRC, kADCVSSNegRef, kADCVDDPosRef));
+	adc_setenabled(1);
+	adc_setchannel(kADCChannelAN2);
+
+	adc_average(10);
+
+	adc_setenabled(0);
+}
+
+void sample_i1()
+{
+	adc_configure(ADCBuildConfig(kADCRightJustified, kFRC, kADCVSSNegRef, kADCVDDPosRef));
+	adc_setenabled(1);
+	adc_setchannel(kADCChannelAN9);
+
+	adc_average(10);
+
+	adc_setenabled(0);
+}

--- a/momo_modules/pv_module/src/sample.h
+++ b/momo_modules/pv_module/src/sample.h
@@ -1,0 +1,6 @@
+//sample.h
+
+void sample_v1();
+void sample_v2();
+void sample_v3();
+void sample_i1();

--- a/momo_modules/pv_module/src/sdcard.c
+++ b/momo_modules/pv_module/src/sdcard.c
@@ -1,0 +1,319 @@
+/*
+ * sdcard.c 
+ * A module for communicating with 
+ *
+ */
+#include "sdcard.h"
+#include "port.h"
+#include "wpu.h"
+#include "pv_defines.h"
+#include "spi2.h"
+
+#define _XTAL_FREQ			4000000
+
+uint8 cmd_packet[6];
+uint8 sector[512];
+
+typedef union
+{
+	SDResponse parsed;
+	uint8 	   data[5];
+} SDResponseUnion;
+
+SDResponseUnion resp;
+
+//Internal Functions
+static void 		sd_initcmd(uint8 cmd);
+static uint8 		sd_sendpacket(SDResponseType rtype);
+static uint8 		sd_sendcommand(SDResponseType rtype);
+static SDErrorCode 	sd_bulktransfer(SDTransferOperation op);
+
+void sd_pins_idle()
+{
+	enable_weak_pullups();
+
+	PIN_TYPE(SDO, DIGITAL);
+	PIN_TYPE(SDI, DIGITAL);
+	PIN_TYPE(SDSEL, DIGITAL);
+
+	PIN_SET(SDO, 0);
+	PIN_SET(SDI, 0);
+	PIN_SET(SDSEL, 0);
+	PIN_SET(SDDET, 0);
+	PIN_SET(SDCLK, 0);
+
+	PIN_DIR(SDO, OUTPUT);
+	PIN_DIR(SDI, OUTPUT);
+	PIN_DIR(SDSEL, OUTPUT);
+	PIN_DIR(SDDET, OUTPUT);
+	PIN_DIR(SDCLK, OUTPUT);
+	PIN_DIR(SDPOW, INPUT);
+}
+
+uint8 sd_power_on()
+{
+	//SDO should drive idle high in case a card is connected
+	enable_pullup(SDI);
+	PIN_SET(SDSEL, 1);
+	PIN_SET(SDO, 1);
+	PIN_SET(SDCLK, 1);
+
+	PIN_SET(SDPOW, 1);
+
+	PIN_DIR(SDI, INPUT);
+	
+	PIN_DIR(SDPOW, OUTPUT);
+
+	__delay_ms(100);
+
+	sd_initialize();
+
+	return 0;
+}
+
+void sd_power_off()
+{
+	PIN_SET(SDO, 0);
+	PIN_SET(SDSEL, 0);
+	PIN_SET(SDCLK, 0);
+
+	PIN_DIR(SDPOW, INPUT);
+	
+	disable_pullup(SDI);
+	PIN_DIR(SDI, OUTPUT);
+	PIN_SET(SDI, 0);
+
+	spi2_setstate(kDisabled);
+}
+
+uint8 sd_check_inserted()
+{
+	PIN_DIR(SDDET, INPUT);
+	enable_pullup(SDDET);
+
+	if (PIN(SDDET) == 1)
+	{
+		disable_pullup(SDDET);
+		PIN_DIR(SDDET, OUTPUT);
+		return 0;
+	}
+
+	disable_pullup(SDDET);
+	PIN_DIR(SDDET, OUTPUT);
+	return 1;
+}
+
+/* Initialization Sequence is per the following documents:
+ * http://mfb.nopdesign.sk/datasheet/cat_d/MMC/spitiming.pdf
+ * https://www.sdcard.org/downloads/pls/simplified_specs/part1_410.pdf
+ */
+SDErrorCode sd_initialize()
+{
+	SPIConfig config;
+	uint8 i;
+
+	config.mode = kSPIMaster_Osc16;
+	config.line_idle = kSPIIdleHigh;
+	config.buffer_overwrite = kSPIOverwriteBuffer;
+	config.clock_edge = kSPIIdleToActive;
+	config.sample_time = kSPISampleEnd;
+
+	spi2_configure(config);
+	spi2_setstate(kEnabled_Sync);
+
+	PIN_SET(SDSEL, 1);
+
+	//Send at least 74 clocks per the SD card spec
+	for (i=0; i<10; ++i)
+		spi2_transfer(0xFF);
+
+	//Send CMD0 with proper CRC code to switch to SPI Mode and reset the card
+	sd_initcmd(0);
+	cmd_packet[5] = 0x95;
+	if (sd_sendcommand(kSDTypeR1) != 0x01)
+		return kSDUnknownError; //Correct response should have only idle bit set
+
+
+	//Increase to maximum speed now that the card is reset successfully
+	config.mode = kSPIMaster_Osc4;
+	spi2_configure(config);
+	spi2_setstate(kEnabled_Sync);
+
+	//Send CMD8 to initialize card and set the voltage range
+	sd_initcmd(8);
+	cmd_packet[3] = 0x01;
+	cmd_packet[4] = 0xAA;
+	cmd_packet[5] = 0x87;
+	if (sd_sendcommand(kSDTypeR3) != 0x1)
+		return kSDUnknownError;
+
+	//Make sure the card accepts our voltage range and echos the test pattern
+	if (resp.data[3] != 0x01 || resp.data[4] != 0xAA)
+		return kSDUnknownError;
+
+	//Now poll telling it we support high capacity cards (SD v2.0)
+	//and wait until it finished initializing and leaves idle mode
+	//Send Cmd55 + ACMD 41 repeatedly to poll for initialized status
+	do
+	{
+		sd_initcmd(55);
+		sd_sendcommand(kSDTypeR1);
+
+		sd_initcmd(41);
+		cmd_packet[1] = 1 << 6;			//set HCS, high capacity support
+		
+	} while(sd_sendcommand(kSDTypeR1) == 0x01);
+
+	if (resp.data[0] != 0x00)
+		return kSDUnknownError;
+
+	//Check to make sure this is an SDHC card.
+	sd_initcmd(58);
+	sd_sendcommand(kSDTypeR3);
+	if ((resp.data[1] & 0b01000000) == 0)
+		return kSDUnknownError;
+
+	return kSDNoError;
+}
+
+/*
+ * Internal function to send an SD command packet and read the response
+ * without controlling the chip select pin so that it can be used with 
+ * normal commands and bulk read and write commands.
+ */
+static uint8 sd_sendpacket(SDResponseType rtype)
+{
+	uint8 i;
+	uint8 tmp;
+
+	for (i=0; i<6; ++i)
+		spi2_transfer(cmd_packet[i]);
+
+	i = 0;
+
+	//Wait until the response appears or we timeout
+	//and then clock in the appropriate number of bytes
+	do
+	{
+		++i;
+		if (i>=SD_TIMEOUT)
+			return kSDTimeoutError;
+
+		tmp = spi2_transfer(0xFF);
+	} while (((tmp & 0x80) != 0));
+
+	//Read in the rest of the response
+	for(i=0; i<(rtype-1); ++i)
+	{
+		resp.data[i] = tmp;
+		tmp = spi2_transfer(0xFF);
+	}
+	resp.data[rtype-1] = tmp;
+
+	return resp.data[0];
+}
+
+/*
+ * Send an SD command over SPI.  Assert CS, send the command, read the response
+ * and then desassert CS.  Also send 1 byte
+ */
+static uint8 sd_sendcommand(SDResponseType rtype)
+{
+	SDErrorCode err;
+
+	PIN_SET(SDSEL,0);
+	err = sd_sendpacket(rtype);
+	PIN_SET(SDSEL,1);
+
+	spi2_transfer(0xFF);
+
+	return err;
+}
+
+static void sd_initcmd(uint8 cmd)
+{
+	cmd_packet[0] = 0b01000000 | (cmd & 0b00111111);
+	cmd_packet[1] = 0x00;
+	cmd_packet[2] = 0x00;
+	cmd_packet[3] = 0x00;
+	cmd_packet[4] = 0x00;
+	cmd_packet[5] = 0x01;
+}
+
+SDErrorCode sd_write(uint32_t blocknum)
+{
+	sd_initcmd(24);
+	cmd_packet[4] = blocknum & 0xFF;
+	cmd_packet[3] = (blocknum >> 8) & 0xFF;
+	cmd_packet[2] = (blocknum >> 16) & 0xFF;
+	cmd_packet[1] = (blocknum >> 24) & 0xFF;
+
+	return sd_bulktransfer(kSDWriteOperation);
+}
+
+SDErrorCode sd_read(uint32_t blocknum)
+{
+	sd_initcmd(17);
+	cmd_packet[4] = blocknum & 0xFF;
+	cmd_packet[3] = (blocknum >> 8) & 0xFF;
+	cmd_packet[2] = (blocknum >> 16) & 0xFF;
+	cmd_packet[1] = (blocknum >> 24) & 0xFF;
+
+	return sd_bulktransfer(kSDReadOperation);
+}
+
+static SDErrorCode sd_bulktransfer(SDTransferOperation op)
+{
+	uint16 i;
+
+	PIN_SET(SDSEL, 0);
+
+	i = sd_sendpacket(kSDTypeR1);
+
+	//SD Card responds with 0x00 if command is accepted
+	if (i != 0)
+	{
+		PIN_SET(SDSEL, 1);
+		spi2_transfer(0xFF);
+		return kSDUnknownError;
+	}
+
+	spi2_transfer(0xFF);			//Need 1 byte of space between command response and start token
+
+	if (op == kSDWriteOperation)
+		spi2_transfer(0xFE); 		//Send the start token
+	else
+	{
+		//Wait until the card sends us a data start token
+		while(spi2_transfer(0xFF) != 0xFE)
+			;		
+	}
+
+	for (i=0; i<512; ++i)
+	{
+		if (op == kSDWriteOperation)
+			spi2_transfer(sector[i]);
+		else
+			sector[i] = spi2_transfer(0xFF);
+	}
+
+	//Transfer fake CRC if writing, read CRC if reading
+	spi2_transfer(0x00);
+	spi2_transfer(0x00);
+
+	if (op == kSDWriteOperation)
+	{
+		//Transfer the response
+		resp.data[0] = spi2_transfer(0xFF);
+		
+		//Wait until the write operation finishes
+		while(spi2_transfer(0xFF) != 0xFF)
+			;
+	}
+
+	PIN_SET(SDSEL, 1);
+
+	spi2_transfer(0xFF);
+
+	return resp.data[0]; 
+}

--- a/momo_modules/pv_module/src/sdcard.c
+++ b/momo_modules/pv_module/src/sdcard.c
@@ -315,5 +315,12 @@ static SDErrorCode sd_bulktransfer(SDTransferOperation op)
 
 	spi2_transfer(0xFF);
 
-	return resp.data[0]; 
+	if (op == kSDReadOperation)
+		return kSDNoError;
+
+	//Check write status code to make sure write was successful
+	if ((resp.data[0] & 0b00011111) != 0b00101)
+		return kSDIOError; 
+
+	return kSDNoError;
 }

--- a/momo_modules/pv_module/src/sdcard.h
+++ b/momo_modules/pv_module/src/sdcard.h
@@ -1,0 +1,81 @@
+//sdcard.h
+
+#ifndef __sdcard_h__
+#define __sdcard_h__
+
+#include "platform.h"
+#include <stdint.h>
+
+#define SD_TIMEOUT		250
+
+//SD Card Response Types
+typedef struct
+{
+	uint8 in_idle_state :1;
+	uint8 erase_reset: 1;
+	uint8 illegal_cmd: 1;
+	uint8 crc_error: 1;
+	uint8 erase_seq_error: 1;
+	uint8 address_error: 1;
+	uint8 param_error: 1;
+	uint8 start_bit: 1;
+} SDResponseByte1;
+
+typedef struct
+{
+	uint8 card_locked :1;
+	uint8 wp_erase_skip: 1;
+	uint8 unspecified_error: 1;
+	uint8 controller_error: 1;
+	uint8 ecc_failed: 1;
+	uint8 wp_violation: 1;
+	uint8 erase_parameter: 1;
+	uint8 out_of_range: 1;
+} SDResponseByte2;
+
+typedef struct
+{
+	SDResponseByte1 b1;
+	SDResponseByte2 b2;
+	uint8 			ocr_reg[3];
+} SDResponse;
+
+typedef enum 
+{
+	kSDTypeR1 = 1,
+	kSDTypeR2 = 2,
+	kSDTypeR3 = 5
+} SDResponseType;
+
+typedef enum
+{
+	kSDNoError = 0,
+	kSDInvalidMBR = 1,
+	kSDInvalidPartition = 2,
+	kSDIOError = 3,
+	kSDFileNotFoundError = 4,
+	kSDFileNotOpenError = 5,
+	kSDInvalidSector = 6,
+	kSDUnknownError = 1<<7,
+	kSDTimeoutError = 0xFF
+} SDErrorCode;
+
+typedef enum
+{
+	kSDWriteOperation = 0,
+	kSDReadOperation = 1
+} SDTransferOperation;
+
+
+void 		sd_pins_idle();
+uint8 		sd_power_on();
+void 		sd_power_off();
+uint8 		sd_check_inserted();
+
+SDErrorCode sd_write(uint32_t block);
+SDErrorCode sd_read(uint32_t block);
+
+SDErrorCode sd_initialize();
+
+
+#endif

--- a/momo_modules/pv_module/src/sdcard.h
+++ b/momo_modules/pv_module/src/sdcard.h
@@ -56,6 +56,7 @@ typedef enum
 	kSDFileNotFoundError = 4,
 	kSDFileNotOpenError = 5,
 	kSDInvalidSector = 6,
+	kSDEOFError = 7,
 	kSDUnknownError = 1<<7,
 	kSDTimeoutError = 0xFF
 } SDErrorCode;

--- a/momo_modules/pv_module/test/test_spi.as
+++ b/momo_modules/pv_module/test/test_spi.as
@@ -1,0 +1,20 @@
+;Name: test_spi
+;Targets: all
+;Type: application
+;Description: Test to ensure that the basic SPI peripheral code
+ is functioning properly  
+
+#include <xc.inc>
+#include "asm_macros.inc"
+#include "symbols.h"
+#include "test_macros.inc"
+#include "test_asserts.inc"
+
+global _begin_tests
+
+PSECT text_unittest,local,class=CODE,delta=2
+BEGINFUNCTION _begin_tests
+	asm_call_sd_initialize()
+	assertlw 0x00
+	return
+ENDFUNCTION _begin_tests

--- a/momo_modules/shared/pic12/src/constants.h
+++ b/momo_modules/shared/pic12/src/constants.h
@@ -8,15 +8,12 @@
 #define __constants_h__
 
 /*
- * The MIB12 executive takes up the lower portion of memory.  This constant defines the
- * first row of program memory that can be used by mib12 applications.  This value must be
- * kept in sync between the mib12 executive, and the build scripts for each application
- * module, i.e. it should not be changed very often.
+ * The MIB12 executive takes up the lower portion of memory.  Application modules
+ * live in the higher portion of memory.
  */
-//#define kFirstApplicationRow	79		Defined in the build system now, see /config/build_settings.json
-#define kAppInitAddress			kFirstApplicationRow*16
-#define kAppInterruptAddress	kFirstApplicationRow*16+1
-#define kAppTaskAddress			kFirstApplicationRow*16+2
+#define kAppInitAddress			kFirstApplicationRow*kFlashRowSize
+#define kAppInterruptAddress	kFirstApplicationRow*kFlashRowSize+1
+#define kAppTaskAddress			kFirstApplicationRow*kFlashRowSize+2
 
 /*
  * MIB12 Application Modules must define a special structure in the 8 high words of program

--- a/momo_modules/shared/pic12/src/peripheral/adc.c
+++ b/momo_modules/shared/pic12/src/peripheral/adc.c
@@ -1,0 +1,48 @@
+//adc.c
+
+#define __ADC_INTERNAL__
+#include "adc.h"
+#include <stdint.h>
+
+unsigned int 	adc_result;
+
+void adc_setenabled(uint8 on)
+{
+	ADON = on;
+}
+
+void adc_convertsync()
+{
+	ADIF = 0;
+	GO = 1;
+
+	while(!ADIF)
+		;
+}
+
+void adc_setchannel(uint8 chan)
+{
+	ADCON0 &= (~kADCChannelMask);
+	ADCON0 |= chan;
+}
+
+void adc_configure(uint8 config)
+{
+	ADCON1 = config;
+}
+
+void adc_average(uint8 n)
+{
+	uint8 i;
+
+	adc_result = 0;
+
+	for(i=0; i<n; ++i)
+	{
+		adc_convertsync();
+		
+		adc_result += ADRESL | (ADRESH << 8);
+	}
+
+	adc_result /= n;
+}

--- a/momo_modules/shared/pic12/src/peripheral/adc.h
+++ b/momo_modules/shared/pic12/src/peripheral/adc.h
@@ -4,6 +4,7 @@
 #define __adc_h__
 
 #include <xc.h>
+#include "platform.h"
 
 #define kADC_CHAN_MASK			0b11111
 #define BUILD_ADC_CHAN(x)		((x & kADC_CHAN_MASK) << 2)
@@ -24,6 +25,7 @@
 #define kADCChannelTemp			BUILD_ADC_CHAN(0b11101)
 #define kADCChannelDAC			BUILD_ADC_CHAN(0b11110)
 #define kADCChannelFVR			BUILD_ADC_CHAN(0b11111)
+#define kADCChannelMask			BUILD_ADC_CHAN(kADC_CHAN_MASK)
 
 //ADC Clock Constants
 #define kADC_CLOCK_MASK			0b111
@@ -34,7 +36,7 @@
 
 //ADC Justification Modes (right justified is shifted all to low order bits)
 #define kADCRightJustified 		(1 << 7)
-#define kADCLeftJustified		0
+#define kADCLeftJustified		0 				//NOT SUPPORTED
 
 //ADC Voltage References
 #define BUILD_ADC_POSREF(x)		((x & 0b11))
@@ -48,5 +50,18 @@
 //Negative References
 #define kADCVSSNegRef			BUILD_ADC_NEGREF(0)
 #define kADCExtNegRef			BUILD_ADC_NEGREF(1)
+
+#define ADCBuildConfig(just, clock, nref, pref)			(just | clock | nref | pref)
+
+//Module Functions
+void adc_setenabled(uint8 on);
+void adc_convertsync();
+void adc_setchannel(uint8 chan);
+void adc_configure(uint8 config);
+void adc_average(uint8 n);
+
+#ifndef __ADC_INTERNAL__
+extern unsigned int 	adc_result;
+#endif
 
 #endif

--- a/momo_modules/shared/pic12/src/peripheral/port.h
+++ b/momo_modules/shared/pic12/src/peripheral/port.h
@@ -1,0 +1,29 @@
+//port.h
+
+#ifndef __port_h__
+#define __port_h__
+
+//Internal macros, not for use
+#define LATCHR(pin)		LAT##pin
+#define TRISR(pin)		TRIS##pin
+#define TYPER(pin)		ANS##pin
+#define PORTR(pin)		R##pin
+
+//Macros for end-user use
+#define OUTPUT			0
+#define INPUT			1
+
+#define DIGITAL 		0
+#define ANALOG 			1
+
+#define LATCH(pin)		LATCHR(pin)
+#define TRIS(pin)		TRISR(pin)
+#define TYPE(pin)		TYPER(pin)
+#define PORT(pin)		PORTR(pin)
+
+#define PIN_DIR(pin, dir)	TRIS(pin) = dir
+#define PIN_SET(pin, val)	LATCH(pin) = val
+#define PIN_TYPE(pin, type) TYPE(pin) = type
+#define PIN(pin) 			(PORT(pin))
+
+#endif

--- a/momo_modules/shared/pic12/src/peripheral/spi1.c
+++ b/momo_modules/shared/pic12/src/peripheral/spi1.c
@@ -1,0 +1,7 @@
+//spi2.c
+
+#define N 1
+#define SSPIE	PIE1,3
+#define SSPIF	PIR1,3
+#include "spi_base.c"
+#undef N

--- a/momo_modules/shared/pic12/src/peripheral/spi1.h
+++ b/momo_modules/shared/pic12/src/peripheral/spi1.h
@@ -1,0 +1,10 @@
+//spi1.h
+
+#ifndef __spi1_h__
+#define __spi1_h__
+
+#define N 1
+#include "spi_base.h"
+#undef N
+
+#endif

--- a/momo_modules/shared/pic12/src/peripheral/spi2.c
+++ b/momo_modules/shared/pic12/src/peripheral/spi2.c
@@ -1,0 +1,7 @@
+//spi2.c
+
+#define N 2
+#define SSPIE	PIE4,0
+#define SSPIF	PIR4,0
+#include "spi_base.c"
+#undef N

--- a/momo_modules/shared/pic12/src/peripheral/spi2.h
+++ b/momo_modules/shared/pic12/src/peripheral/spi2.h
@@ -1,0 +1,10 @@
+//spi2.h
+
+#ifndef __spi2_h__
+#define __spi2_h__
+
+#define N 2
+#include "spi_base.h"
+#undef N
+
+#endif

--- a/momo_modules/shared/pic12/src/peripheral/spi_base.c
+++ b/momo_modules/shared/pic12/src/peripheral/spi_base.c
@@ -1,0 +1,75 @@
+//spi_base.c
+
+#include "spi_base.h"
+#include "bit_utilities.h"
+
+//SSPIE and SSPIF must be defined specifically for each MSSP peripheral, see spi2.c.
+
+#define SSPSTAT 	p_reg(SSP, N, STAT)
+#define SSPCON1		p_reg(SSP, N, CON1)
+#define SSPCON3		p_reg(SSP, N, CON3)
+#define SSPADD		p_reg(SSP, N, ADD)
+#define SSPBUF		p_reg(SSP, N, BUF)
+
+#define SSP_WCOL		SSPCON1,7
+#define SSP_BF			SSPSTAT,0
+#define SSP_OV			SSPSTAT,7
+#define SSP_OVERWRITE 	SSPCON3,4
+#define SSP_ENABLE		SSPCON1,5
+
+//spi_init
+void p_fun(spi, N, configure)(SPIConfig config)
+{
+	SSPCON1 = config.value & SPICON1MASK;
+	SSPSTAT = config.value & SPISTATMASK;
+
+	if (config.buffer_overwrite)
+		bit_set(SSP_OVERWRITE);
+	else
+		bit_clear(SSP_OVERWRITE);
+}
+
+//spi_setenabled
+void p_fun(spi, N, setstate)(PeripheralState state)
+{
+	if (state == kDisabled)
+	{
+		bit_clear(SSP_ENABLE);
+		bit_clear(SSPIE);
+	}
+	else
+	{
+		bit_clear(SSPIF);
+		if (state == kEnabled_Async)
+			bit_set(SSPIE);
+
+		SSPBUF;
+
+		bit_set(SSP_ENABLE);
+	}
+}
+
+//spi_setrate
+void p_fun(spi, N, setrate)(uint8 baud)
+{
+	SSPADD = baud;
+}
+
+//spi_transfer
+uint8 p_fun(spi, N, transfer)(uint8 val)
+{
+	bit_clear(SSP_WCOL);
+	bit_clear(SSP_OV);
+
+	bit_clear(SSPIF);
+	SSPBUF = val;
+
+	//Asynchronous Mode - return immediately
+	if (bit(SSPIE))
+		return 0;
+
+	while (!bit(SSPIF))
+		;
+
+	return SSPBUF;
+}

--- a/momo_modules/shared/pic12/src/peripheral/spi_base.h
+++ b/momo_modules/shared/pic12/src/peripheral/spi_base.h
@@ -1,0 +1,72 @@
+
+#include <xc.h>
+#include "peripheral_def.h"
+#include "platform.h"
+
+#define SPICON1MASK		0b00011111
+#define SPISTATMASK		0b11000000
+
+//Valid SPI Modes
+enum
+{
+	kSPIMaster_Osc4  = 0b0000,
+	kSPIMaster_Osc16 = 0b0001,
+	kSPIMaster_Osc64 = 0b0010,
+	kSPIMaster_TMR2	 = 0b0011,
+	kSPIMaster_BRGEN = 0b1010,
+
+	kSPISlave_SSOn	 = 0b0100,
+	kSPISlave_SSOff	 = 0b0101
+};
+
+//Valid SPI Line Idle Conditions
+//When the line is not being asserted, should it idle high or low
+enum
+{
+	kSPIIdleLow = 0,
+	kSPIIdleHigh = 1
+};
+
+//Valid SPI Clock Edge Timings
+//Defines on what edge of the clock the module outputs data
+enum
+{
+	kSPIIdleToActive = 0,
+	kSPIActiveToIdle = 1
+};
+
+//Valid SPI Data Sampling Timings
+enum
+{
+	kSPISampleMiddle = 0,
+	kSPISampleEnd = 1
+};
+
+//Valid SPI Buffer Overwrite Settings
+//Only takese effect in SPI slave mode
+enum
+{
+	kSPIOverwriteBuffer = 1,
+	kSPINoOverwriteBuffer = 0
+};
+
+//SPI Configuration Structure
+typedef union
+{
+	struct 
+	{
+		uint8	mode: 4;
+		uint8 	line_idle : 1;
+		uint8	buffer_overwrite: 1;
+		uint8	clock_edge : 1;
+		uint8	sample_time: 1;
+	};
+
+	uint8 value;
+} SPIConfig;
+
+//Peripheral Module API
+void  p_fun(spi, N, configure)(SPIConfig config);		//spiN_init
+void  p_fun(spi, N, setrate)(uint8 rate);				//spiN_setrate
+void  p_fun(spi, N, setstate)(PeripheralState state);   //spiN_setenabled
+uint8 p_fun(spi, N, transfer)(uint8 val);

--- a/momo_modules/shared/pic12/src/peripheral/wpu.h
+++ b/momo_modules/shared/pic12/src/peripheral/wpu.h
@@ -1,0 +1,16 @@
+#ifndef __WPU_H__
+#define __WPU_H__
+
+#include <xc.h>
+
+//Internal Routines
+#define set_pullupr(x)		(WPU##x = 1)
+#define clear_pullupr(x)	(WPU##x = 0)
+
+//User Callable Routines
+#define enable_pullup(x)		set_pullupr(x)
+#define disable_pullup(x)		clear_pullupr(x)
+#define enable_weak_pullups()	nWPUEN = 0
+#define disable_weak_pullups()	nWPUEN = 1
+
+#endif

--- a/momo_modules/shared/pic12/src/peripheral_def.h
+++ b/momo_modules/shared/pic12/src/peripheral_def.h
@@ -1,0 +1,38 @@
+#ifndef __peripheral_def_h__
+#define __peripheral_def_h__
+
+#include "bit_utilities.h"
+
+/*
+ * Macros to support defining perihperal functions that can be reused
+ * with multiple peripherals of the same type.  The PIC12 has family
+ * standard peripherals so it makes sense to write just 1 version of the
+ * code for each peripheral and use macros to choose the right registers
+ * to control, e.g. mssp1 vs mssp2 since the two are identical, just 
+ */
+
+#define pdefine_f(periph, num, fun)	periph##num##_##fun
+#define pdefine_r(periph, num, fun)	periph##num##fun
+#define p_fun(p, n, f)				pdefine_f(p, n, f)
+#define p_reg(p, n, f)				pdefine_r(p, n, f)
+
+ /*
+  * Common Bit Utilities
+  */
+#define bit_set(x)		SET_BIT(x)
+#define bit_clear(x)	CLEAR_BIT(x)
+#define bit(x)			BIT(x)			
+
+ /*
+  * Common Peripheral-Wide Definitions
+  *
+  */
+
+ typedef enum
+ {
+ 	kDisabled = 0,
+ 	kEnabled_Sync = 1,
+ 	kEnabled_Async = 2
+ } PeripheralState;
+
+#endif

--- a/momo_modules/shared/portable/util/bit_utilities.h
+++ b/momo_modules/shared/portable/util/bit_utilities.h
@@ -4,6 +4,7 @@
 #define CLEAR_BIT(field, bitnum) ((field) &= ~(1<<bitnum))
 #define SET_BIT(field,bitnum)    ((field) |= 1<<bitnum)
 #define TOGGLE_BIT(field,bitnum) ((field) ^= 1<<bitnum)
+#define BIT(field, bitnum) 		 ((field) & (1 << bitnum))
 
 //For this macro, field should be an unsigned variable because of the the right shift operator
 #define BIT_TEST(field, bitnum)  ((field & (1 << bitnum)) >> bitnum)

--- a/tools/python_tools/dump_fat.py
+++ b/tools/python_tools/dump_fat.py
@@ -1,0 +1,127 @@
+#dump_fat.py
+
+import sys
+import struct
+
+def read_sector(dev, s, num=1):
+	dev.seek(s*512)
+	return dev.read(512*num)
+
+def readNum(buf, f, offset):
+	fmt = '<' + f
+
+	(res,) = struct.unpack_from(fmt, buf, offset=offset)
+
+	return res
+
+def read16(buf, offset):
+	return readNum(buf, 'H', offset)
+
+def read32(buf, offset):
+	return readNum(buf, 'I', offset)
+
+def read8(buf, offset):
+	return readNum(buf, 'B', offset)
+
+def read_fat(dev, sect):
+	fmt = '<128I'
+
+	return struct.unpack(fmt, read_sector(dev, sect))
+
+def read_mbr(dev):
+	part_fmt = "<B3xB3xII"
+	magic_fmt = "<H"
+	mbr = read_sector(dev, 0)
+
+	(magic,) = struct.unpack_from(magic_fmt, mbr, offset=510)
+
+	print magic
+
+	if magic != 0xAA55:
+		raise ValueError("Invalid MBR Magic Number: 0x%X" % magic)
+
+	parts = [struct.unpack_from(part_fmt, mbr, offset=446+16*x) for x in xrange(0,4)]
+
+	pdicts = []
+	for part in parts:
+		d = {"first_sector": part[2], "num_sectors": part[3]}
+		pdicts.append(d)
+
+	return pdicts
+
+def get_clusterval(dev, cluster, part):
+	fat_begin = part['part_start'] + part['num_reserved']
+
+	sect_idx = cluster / (128)
+	offset = cluster % (128)
+
+	clusters = read_fat(dev, sect_idx)
+
+	return clusters[offset]
+
+def get_chain(dev, start_cluster):
+	fat 
+
+def read_fat32part(dev, offset):
+	part = read_sector(dev, offset)
+
+	partinfo = {}
+
+	partinfo['bytes_per_sector'] = read16(part, 0x0B)
+	partinfo['sects_per_cluster'] = read8(part, 0x0D)
+	partinfo['num_reserved'] 	= read16(part, 0x0E)
+	partinfo['num_fats'] = read8(part, 0x10)
+	partinfo['sects_per_fat'] = read32(part, 0x24)
+	partinfo['root_cluster'] = read32(part, 0x2C)
+	partinfo['part_start'] = offset
+	partinfo['cluster_start'] = offset + partinfo['num_reserved'] + partinfo['num_fats']*partinfo['sects_per_fat']
+
+	return partinfo	
+
+def read_cluster(dev, cluster, part):
+	start_sect = (cluster - 2)*part['sects_per_cluster'] + part['cluster_start']
+
+	return read_sector(dev, start_sect, part['sects_per_cluster'])
+
+def read_dir(dev, cluster, part):
+	data = read_cluster(dev, cluster, part)
+
+	dirfmt = '<11sB8xH4xHI'
+
+	numents = len(data) / 32
+
+	ents = []
+	for i in xrange(0,numents):
+		(name, attrib, clust_high, clust_low, size) = struct.unpack_from(dirfmt, data, offset=32*i)
+		if name[0] == '\0':
+			continue
+		if name[0] == '\xE5':
+			continue
+		if attrib & 0xF == 0xF:
+			continue
+
+		clust = clust_high << 16 | clust_low
+		ent = {'name': name, 'cluster': clust, 'size': size, 'attrib': attrib}
+
+		ents.append(ent)
+
+	return ents
+
+if len(sys.argv) != 2:
+	print "Usage: dump_fat <device>"
+	sys.exit(1)
+
+with open(sys.argv[1], "rb", buffering=-1) as dev:
+	parts = read_mbr(dev)
+	part = parts[0]
+
+	print "Partition 1"
+	print "* Start: %d" % part['first_sector']
+	print "* Size:  %d sectors" % part['num_sectors']
+
+	f32info = read_fat32part(dev, part['first_sector'])
+
+	ents = read_dir(dev, f32info['root_cluster'], f32info)
+	log = ents[0]
+
+	print "Size: 0x%X" % log['size']

--- a/tools/python_tools/process_log.py
+++ b/tools/python_tools/process_log.py
@@ -1,0 +1,265 @@
+#pv_log.py
+#Process the log file created by the pv_module into a csv file
+
+import sys
+import csv
+import cmdln
+import struct
+import os.path
+
+class LogFile:
+	intervals = {'1s': 0, '2s': 1, '4s': 2,'8s': 3,'16s': 4,'32s': 5,'64s': 6,'128s': 7,'256s': 8}
+	inv_map = ['1 second', '2 seconds', '4 seconds','8 seconds','16 seconds','32 seconds','64 seconds','128 seconds','256 seconds']
+
+	default_int = 6
+
+	def __init__(self, path):
+		self.file = open(path, "r+b")
+		self._read_info()
+		self._calculate()
+
+	def _read_info(self):
+		self.file.seek(0)
+		fmt = "<IIB"
+
+		data = self.file.read(9)
+
+		(magic, valid_sectors, int_num) = struct.unpack(fmt, data)
+
+
+		if magic == 0x78563412:
+			self.valid_file = True
+			self.valid_sectors = valid_sectors-1
+
+			if int_num < len(self.inv_map):
+				self.interval = self.inv_map[int_num]
+				self.intnum = int_num
+			else:
+				self.interval = "INVALID (value=%d)" % int_num
+				self.intnum = self.default_int
+
+		else:
+			self.valid_file = False
+			self.valid_sectors = -1
+			self.interval = "INVALID"
+			self.intnum = self.default_int
+
+	def _calculate(self):
+		self.num_entries = self.valid_sectors * 512 / 16
+
+	def process(self, v1, v2, v3, i1):
+		v1_o = v1/1024. * 20*2.8/2.78
+		v2_o = v2/1024. * 20*2.8/2.78
+		v3_o = v3/1024. * 25*2.8/2.78
+		i1_o = i1/1024. * 2.78 / 0.001 / 100
+
+		return {"v1": v1_o, "v2": v2_o, "v3": v3_o, "i1": i1_o}
+
+	def enum_entries(self, skip, num):
+		entry_fmt = "<IIHHHH"
+		
+		if num < 0:
+			num = self.num_entries
+
+		for i in xrange(skip, min(self.num_entries, skip+num)):
+			self.file.seek(512 + i*16)
+			data = self.file.read(16)
+			(mag1, mag2, v1, v2, v3, i1) = struct.unpack(entry_fmt, data)
+
+			if mag1 != 0xDDCCBBAA or mag2 != 0x9955FFEE:
+				continue
+
+			yield ((v1, v2, v3, i1), self.process(v1, v2, v3, i1))
+
+	def map_interval(self, interval):
+		if interval in self.intervals:
+			return self.intervals[interval]
+
+		return self.default_int
+
+	def close(self):
+		self.file.close()
+
+	def write_toc(self, valid, interval):
+		self.file.seek(0)
+		
+		fmt = "<IIB"
+
+		if interval is None:
+			interval = self.intnum
+		elif interval not in self.intervals:
+			print "WARNING: Invalid interval specified, using default value"
+
+		int_num = self.map_interval(interval)
+
+		#A valid value < 1 means to keep the current number of valid sectors
+		if valid < 1:
+			valid = self.valid_sectors+1
+
+		header = struct.pack(fmt, 0x78563412, max(valid, 1), int_num)
+		self.file.write(header)
+		self.file.flush()
+
+class PVCommands(cmdln.Cmdln):
+	name = 'pv_log'
+
+	def do_info(self, subcmd, opts, log_file):
+		"""${cmd_name}: Print info about the log file specified
+
+		Detailed information is given about the number of log entries,
+		the log file size and other interesting information.
+		${cmd_usage}
+		${cmd_option_list}
+		LOG_FILE should be a path to a log file (log.bin) produced by the
+		MoMo solar logging module.
+		"""
+
+		try:
+			log = LogFile(log_file)
+		except IOError:
+			print "Error: could not open log file: %s" % log_file
+			return 1
+
+		print "Log File Information"
+		print "File Valid: %s" % log.valid_file
+		print "Number of Sectors Used: %d" % log.valid_sectors
+		print "Number of Datapoints Logged: %d" % log.num_entries 
+		print "Logging Interval: %s" % log.interval
+		return 0
+
+	@cmdln.option('-s', '--skip', action='store', type=int, default=0, help='skip the first SKIP entries')
+	@cmdln.option('-n', '--num', action='store', type=int, default=-1, help='print only NUM entries')
+	def do_print(self, subcmd, opts, log_file):
+		"""${cmd_name}: Print all or a subset of the log entries to stdout
+
+		${cmd_usage}
+		${cmd_option_list}
+		LOG_FILE should be a path to a log file (log.bin) produced by the
+		MoMo solar logging module.
+		"""
+
+		try:
+			log = LogFile(log_file)
+		except IOError:
+			print "Error: could not open log file: %s" % log_file
+			return 1
+
+		for raw, proc in log.enum_entries(opts.skip, opts.num):
+			print "V1: %.2fV || V2: %.2fV || V3: %.2fV || Current: %.2fA" % (proc['v1'], proc['v2'], proc['v3'], proc['i1'])
+
+		return 0
+
+	@cmdln.option('-o', '--out', action='store', default='log.csv', help='output CSV file to be generated')
+	@cmdln.option('-s', '--skip', action='store', type=int, default=0, help='skip the first SKIP entries')
+	@cmdln.option('-n', '--num', action='store', type=int, default=-1, help='print only NUM entries')
+	def do_convert(self, subcmd, opts, log_file):
+		"""${cmd_name}: Convert a binary log file (log.bin) to a CSV spreadsheet
+
+		${cmd_usage}
+		${cmd_option_list}
+		LOG_FILE should be a path to a log file (log.bin) produced by the
+		MoMo solar logging module.
+		"""
+
+		try:
+			log = LogFile(log_file)
+		except IOError:
+			print "Error: could not open log file: %s" % log_file
+			return 1
+
+		try:
+			out = open(opts.out, "w")
+			writer = csv.writer(out)
+		except IOError:
+			log.close()
+			print "Error: could not create output file: %s" % opts.out
+			return 1
+
+		headers = ['Voltage 1 (V)', 'Voltage 2 (V)', 'Voltage 3 (V)', 'Current (A)', 'Raw V1', 'Raw V2', 'Raw V3', 'Raw Current']
+		writer.writerow(['WellDone PV Logging Module v1'])
+		writer.writerow(['Logging Interval: %s' % log.interval])
+		writer.writerow(headers)
+		for raw, proc in log.enum_entries(opts.skip, opts.num):
+			row = [proc['v1'], proc['v2'], proc['v3'], proc['i1'], raw[0], raw[1], raw[2], raw[3]]
+			writer.writerow(row)
+
+		out.close()
+
+		return 0
+
+	@cmdln.option('-s', '--size', action='store', type=int, default=1024*1024*128, help='file size (default is 128MB)')
+	@cmdln.option('-i', '--interval', type='choice', choices=['1s', '2s', '4s','8s','16s','32s','64s','128s','256s'], default='64s', help='Logging interval (default: 64s)')
+	def do_create(self, subcmd, opts, directory):
+		"""${cmd_name}: Create a new log file in the specified directory
+
+		${cmd_usage}
+		${cmd_option_list}
+		DIRECTORY should be a path to the root directory of the SD card that 
+		will be used for logging.  The log file must be completely preallocated,
+		meaning that the size you specify in this command will limit how large of
+		a log the data logger can produce.  The logger will log data at the interval
+		specified with the -i option.  
+
+		Possible logging intervals are 1s, 4s, 8s, 16s, 32s, 64s (default), 128s and 256s.
+		"""
+
+		block = 4096
+		numblocks = opts.size / block
+		remainder = opts.size % block
+
+		log_file = os.path.join(directory, 'log.bin')
+
+		blockbuff = "\0" * block
+
+		with open(log_file, "w") as f:
+			for i in xrange(0, numblocks):
+				f.write(blockbuff)
+
+			remblock = "\0" * remainder
+			f.write(remblock)
+
+		try:
+			log = LogFile(log_file)
+		except IOError:
+			print "Error: could not open log file: %s" % log_file
+			return 1
+
+		log.write_toc(1, opts.interval)
+		log.close()
+
+		return 0
+
+	@cmdln.option('-t', '--truncate', action='store_true', help='erase all logged data')
+	@cmdln.option('-i', '--interval', type='choice', choices=['1s','2s','4s','8s','16s','32s','64s','128s','256s'], default=None, help='Logging interval (default: 64s)')
+	def do_adjust(self, subcmd, opts, log_file):
+		"""${cmd_name}: Create a new log file in the specified directory
+
+		${cmd_usage}
+		${cmd_option_list}
+		Adjust the logging settings specified by this log.bin file.  You can update
+		the logging interval and/or erase all of the logged data in the file
+		LOG_FILE should be a path to a log file (log.bin) produced by the
+		MoMo solar logging module.
+
+		Possible logging intervals are 1s, 4s, 8s, 16s, 32s, 64s (default), 128s and 256s.
+		"""
+
+		valid = -1
+
+		if opts.truncate:
+			valid = 1
+
+		try:
+			log = LogFile(log_file)
+		except IOError:
+			print "Error: could not open log file: %s" % log_file
+			return 1
+
+		log.write_toc(valid, opts.interval)
+		log.close()
+
+		return 0
+
+if __name__ == "__main__":
+	pv = PVCommands()
+	sys.exit(pv.main())

--- a/tools/python_tools/process_log.py
+++ b/tools/python_tools/process_log.py
@@ -169,7 +169,7 @@ class PVCommands(cmdln.Cmdln):
 
 		try:
 			out = open(opts.out, "w")
-			writer = csv.writer(out)
+			writer = csv.writer(out, lineterminator='\n')
 		except IOError:
 			log.close()
 			print "Error: could not create output file: %s" % opts.out

--- a/tools/scripts/app_check.py
+++ b/tools/scripts/app_check.py
@@ -8,10 +8,10 @@ import sys
 ih = intelhex.IntelHex(sys.argv[1])
 ih.padding = 0xFF
 
-start_row = 79
-start_addr = 79*16
+start_row = 44
+start_addr = start_row*32
 
-end_addr = 128*16
+end_addr = 4096
 
 check = 0
 for i in xrange(start_addr, end_addr):
@@ -27,4 +27,5 @@ for i in xrange(start_addr, end_addr):
 check = check & 0xFF
 
 print "Checksum: 0x%X" % check
+print "Checksum: %d" % check
 print "Checksum: %s" % bin(check)

--- a/tools/scripts/compare_hex.py
+++ b/tools/scripts/compare_hex.py
@@ -1,0 +1,23 @@
+#compare_hex.py
+
+import intelhex
+import sys
+
+def print_diff(standard, test):
+	valid_addr = standard.addresses()
+
+	
+	for addr in valid_addr:
+		if standard[addr] != test[addr]:
+			a = addr / 2
+			high = addr % 2
+
+			if high:
+				print "Difference at 0x%X, high byte (wanted 0x%X, was 0x%X)" % (a, standard[addr], test[addr])
+			else:
+				print "Difference at 0x%X, low byte (wanted 0x%X, was 0x%X)" % (a, standard[addr], test[addr])
+
+standard = intelhex.IntelHex(sys.argv[2])
+test = intelhex.IntelHex(sys.argv[1])
+
+print_diff(standard, test)

--- a/tools/scripts/print_mibmap.py
+++ b/tools/scripts/print_mibmap.py
@@ -1,0 +1,75 @@
+import intelhex
+import sys
+
+ih = intelhex.IntelHex16bit(sys.argv[1])
+
+numfeataddr = 0x7FA
+getfeataddr = 0x7FB
+getcmdaddr = 0x7FC
+gethanaddr = 0x7FE
+magicaddr = 0x7FF
+
+print "MIB Block at 0x7F0"
+print "Magic Number: 0x%X" % ih[magicaddr]
+
+def decode(ih, addr):
+	instr = ih[addr]
+
+	prefix = instr >> 11
+	retpref = instr >> 8
+	lowbyte = instr & 0xFF
+
+	if prefix == 0b101:
+		return ('goto', instr & ((1 << 11)-1))
+	elif prefix == 0b110:
+		if retpref == 0b110100:
+			return ('retlw', instr & 0xFF)
+		elif retpref == 0b110001:
+			return ('movlp', instr & 0xFE)
+	elif prefix == 0:
+		if lowbyte == 0b1011:
+			return ('brw', 1)
+		
+
+	print "Unknown Instruction at 0x%X: 0x%X" % (addr, instr)
+	print "Prefix was: %s" % bin(prefix)
+	print "High byte was: %s" % bin(retpref)
+def process_instr(ih, page, addr):
+	instr = decode(ih, addr)
+
+	print "0x%X: %s 0x%X" % (addr, instr[0], instr[1])
+
+	mno = instr[0]
+	newaddr = addr + 1
+
+	if mno == 'goto':
+		newaddr = instr[1] | ((page & 0b01111000) << 8)
+		return (page, newaddr)
+	elif mno == 'movlp':
+		return (instr[1], newaddr)
+	elif mno == 'brw':
+		return(page, newaddr + instr[1])
+	elif mno == 'retlw':
+		return None
+
+def find_return(ih, addr):
+	page = 0
+	while True:
+		x = process_instr(ih, page, addr)
+		if x is None:
+			break
+		
+		page = x[0]
+		addr = x[1]
+
+print "Get Feature"
+#find_return(ih, getfeataddr)
+
+print "Number of Features"
+#find_return(ih, numfeataddr)
+
+print "Get Command"
+#find_return(ih, getcmdaddr)
+
+print "Get Handler"
+find_return(ih, gethanaddr)

--- a/tools/site_scons/mib12_config.py
+++ b/tools/site_scons/mib12_config.py
@@ -18,6 +18,8 @@ class MIB12Processor:
 		self.app_rom = [self.exec_rom[1] +1, self.settings['total_rom']-1]
 
 		self.api_range = [self.app_rom[0] - 16, self.app_rom[0] - 1]
-		self.mib_range = [self.app_rom[1] - 15, self.app_rom[1]]
+		self.mib_range = [2048 - 17-16, 2047] #mib map is currently 17 bytes long (not 16)
 
-		self.first_app_page = self.app_rom[0] / 16
+		self.row_size = self.settings['flash_row_words']
+		self.total_prog_mem = self.settings['total_rom']
+		self.first_app_page = self.app_rom[0] / self.row_size

--- a/tools/site_scons/pic12_unit.py
+++ b/tools/site_scons/pic12_unit.py
@@ -82,10 +82,10 @@ def build_unittest(test_files, name, chip, type):
 
 	outscript = env.Command([os.path.join(outdir, 'test.stc')], [outhex], action=build_unittest_script)
 
-	raw_results = env.gpsim_run(build_logfile_name(env), outscript)
-	formatted_log = env.Command([build_formatted_log_name(env), build_status_name(env)], [raw_results, symtab], action=process_unittest_log)
+	raw_log_path = os.path.join(outdir, build_logfile_name(env))
 
-	env.Command(build_formatted_log_name(env) + 'nonexistant', [], Delete(raw_results))
+	raw_results = env.gpsim_run(raw_log_path, outscript)
+	formatted_log = env.Command([build_formatted_log_name(env), build_status_name(env)], [raw_results, symtab], action=process_unittest_log)
 
 	#Also remember to remove the test directory when cleaning
 	env.Clean(outscript, testdir)
@@ -107,7 +107,7 @@ def build_unittest_script(target, source, env):
 	Build a gpsim script to execute this unit test
 	"""
 
-	logfile = os.path.join('..', '..', 'output', env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.raw')
+	logfile = env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.raw'
 
 	sim = env['TESTCHIP']
 	name = env['TESTNAME']
@@ -132,10 +132,10 @@ def process_unittest_log(target, source, env):
 
 
 def build_logfile_name(env):
-	return os.path.join('build', 'test', 'output', env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.raw')
+	return env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.raw'
 
 def build_formatted_log_name(env):
-	return os.path.join('build', 'test', 'output', env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.log')
+	return os.path.join('build', 'test', 'output', 'logs', env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.log')
 
 def build_status_name(env):
 	return os.path.join('build', 'test', 'output', env['TESTNAME'] + '_' + env['TESTAPPEND'] + '.status')

--- a/tools/site_scons/utilities.py
+++ b/tools/site_scons/utilities.py
@@ -138,7 +138,7 @@ class MIB12Config:
 		exec_range = self.chip_def(chip, 'executive_rom')
 
 		env['ROMSTART'] = exec_range[0]
-		env['ROMEND'] = exec_range[1]
+		env['ROMEND'] = exec_range[1] - 16 - 1 #Make sure we don't overlap the MIB API in the high part of memory
 
 		env['XC8FLAGS'] += self.common_flags
 		env['XC8FLAGS'] += self.exec_flags
@@ -158,10 +158,16 @@ class MIB12Config:
 		self._ensure_flags(env)
 		self.config_env_for_chip(chip, env)
 
+		info = env['CHIPINFO']
+
 		exec_range = self.chip_def(chip, 'executive_rom')
 
 		env['ROMSTART'] = exec_range[1]+1
-		env['ROMEND'] = self.chip_def(chip, 'total_rom') - 16 - 1 #Make sure we don't let the code overlap with the MIB map in high memory
+		env['ROMEND'] = self.chip_def(chip, 'total_rom') - 1 
+
+		#Make sure we don't let the code overlap with the MIB map in high memory
+		env['ROMEXCLUDE'] = []
+		env['ROMEXCLUDE'].append(info.mib_range)
 
 		env['XC8FLAGS'] += self.common_flags
 		env['XC8FLAGS'] += self.app_flags
@@ -186,6 +192,8 @@ class MIB12Config:
 			env['CHIP'] = self.chip_def(chip, 'xc8_target')
 			env['CHIPDEFINE'] = self.chip_def(chip, 'xc8_define')
 			env['XC8FLAGS'] += ['-DkFirstApplicationRow=%d' % info.first_app_page]
+			env['XC8FLAGS'] += ['-DkFlashRowSize=%d' % info.row_size]
+			env['XC8FLAGS'] += ['-DkFlashMemorySize=%d' % info.total_prog_mem]
 			env['MIB_API_BASE'] = str(info.api_range[0])
 		except KeyError:
 			raise ValueError("Chip %s not found in build_settings.json, cannot target that chip." % chip)


### PR DESCRIPTION
The PV Logging Module has release level functionality:
- flexible logging intervals
- completely configurable via sd card by editing a file on the SD card that is read upon insertion into the device
- limited FAT32 filesystem driver allowing writing to already existing files
- process_log.py file allows for reading and converting the logging information output by the module.  Also allows for configuring the module by embedding config information in the logging file.

In order to support this module, which runs on a pic16lf1847, the mib12 executive has been updated to properly support application modules and chips with more than 2K of ROM and applications that are paged.  Bootloader can support up to 8K of ROM and the pic12 executive properly guards itself against page changes by the application.
