### PR TITLE
Fixed momo-commander for compiling on mac os x

### DIFF
--- a/tools/momo-commander/makefile
+++ b/tools/momo-commander/makefile
@@ -9,7 +9,7 @@ OBJS = \
 all: out/momo-commander
 
 out/momo-commander: $(OBJS)
-	g++ -o out/momo-commander $^ -L./lib/D2XX/mac/bin/10.5-10.7/ -lftd2xx
+	g++ -o out/momo-commander $^ -L./lib/D2XX/mac/bin/10.5-10.7/ -lftd2xx.1.2.2
 
 tmp/%.o: src/%.cpp
 	g++ -g -o $@ -c $<

--- a/tools/momo-commander/src/CommanderShell.cpp
+++ b/tools/momo-commander/src/CommanderShell.cpp
@@ -30,7 +30,7 @@ CMDRES::CODE connect( const Shell& shell, const ArgList& args ) {
 	std::string deviceID = "";
 	for ( int i=0; i<args.size(); ++i )
 	{
-		if ( args[i] == "-D" )
+		if ( strcmp(args[i], "-D") == 0 )
 		{
 			if ( i+1 < args.size() ) {
 				deviceID = args[++i];

--- a/tools/momo-commander/src/FTDIConnection.cpp
+++ b/tools/momo-commander/src/FTDIConnection.cpp
@@ -1,4 +1,5 @@
 #include "FTDIConnection.h"
+#include <stdlib.h>
 
 bool FTDIConnection::Open() {
 	FT_STATUS ftStatus;

--- a/tools/momo-commander/src/FTDIManager.h
+++ b/tools/momo-commander/src/FTDIManager.h
@@ -26,4 +26,4 @@ private:
 	FTDIConnectionList m_connections;
 };
 
-#endif;
+#endif

--- a/tools/momo-commander/src/FTDIShell.cpp
+++ b/tools/momo-commander/src/FTDIShell.cpp
@@ -1,4 +1,5 @@
 #include "FTDIShell.h"
+#include <unistd.h>
 
 #define BUF_SIZE 10
 MoMoResponseStatus searchChars[3] = { kMoMoPending, kMoMoSuccess, kMoMoFailure };
@@ -44,7 +45,8 @@ FTDIShell::FTDIShell( FTDIConnection& connection, FILE* input )
 {
 	SetPrompt( "FSU" );
 	if (m_connection.Active()) {
-		if ( !Activate() );
+		if ( !Activate() )
+			;
 	}
 }
 

--- a/tools/momo-commander/src/Shell.cpp
+++ b/tools/momo-commander/src/Shell.cpp
@@ -108,6 +108,8 @@ CMDRES::CODE Shell::Do( const ArgList& in_args ) {
 		};
 		Prompt();
 	}
+
+	return CMDRES::kError;
 }
 
 void Shell::RegisterCommand( const std::string& name, command_handler handler ) {


### PR DESCRIPTION
- Library paths were incorrect on my macbook
- invalid string comparison, need to use strcmp in C/C++
- cleaned up some code
- needed extra include of stdlib on some platforms
