### PR TITLE
Don't require a port when using modtool

### DIFF
--- a/tools/bin/modtool
+++ b/tools/bin/modtool
@@ -22,7 +22,6 @@ class ModTool(cmdln.Cmdln):
 		${cmd_usage}
 		${cmd_option_list}
 		"""
-		self.assert_args(opts, ['port'])
 
 		con = self._get_controller(opts)
 		mods = con.enumerate_modules()
@@ -39,7 +38,6 @@ class ModTool(cmdln.Cmdln):
 		${cmd_usage}
 		${cmd_option_list}
 		"""
-		self.assert_args(opts, ['port'])
 		
 		con = self._get_controller(opts)
 		mod = con.describe_module(int(index))
@@ -68,7 +66,6 @@ class ModTool(cmdln.Cmdln):
 		${cmd_option_list}
 		"""
 
-		self.assert_args(opts, ['port'])
 		con = self._get_controller(opts)
 		reflash_module(con, hexfile, name=opts.name, address=int(opts.address))
 
@@ -79,11 +76,6 @@ class ModTool(cmdln.Cmdln):
 			self.error(str(e))
 
 		return c
-
-	def assert_args(self, opts, args):
-		for arg in args:
-			if not hasattr(opts, arg) or getattr(opts, arg) is None:
-				self.error("You must specify an argument for %s" % arg)
 
 	def error(self, text):
 		print Fore.RED + "Error Occurred: " + Style.RESET_ALL + text

--- a/tools/pymomo/commander/exceptions.py
+++ b/tools/pymomo/commander/exceptions.py
@@ -9,3 +9,10 @@ class RPCException:
 	def __init__(self, type, data):
 		self.type = type
 		self.data = data
+
+class InitializationException:
+	def __init__(self, description):
+		self.message = description
+
+	def __str__(self):
+		return self.message

--- a/tools/pymomo/commander/meta/initialization.py
+++ b/tools/pymomo/commander/meta/initialization.py
@@ -30,6 +30,4 @@ def find_momo_serial():
 	"""
 	for port, desc, hwid in sorted( list_ports.comports() ):
 		if re.match( r"USB VID:PID=403:(\d+).*", hwid) != None:
-			continue
-		else:
 			return port

--- a/tools/pymomo/commander/meta/initialization.py
+++ b/tools/pymomo/commander/meta/initialization.py
@@ -2,14 +2,34 @@ from pymomo.commander import transport, cmdstream
 from pymomo.commander.proxy import *
 from pymomo.commander.exceptions import *
 
-def get_controller(serial_port):
+import serial
+from serial.tools import list_ports
+import re
+
+def get_controller(serial_port=None):
 	"""
 	Given serial port descriptor, create all of the necessary
 	object to get a controller proxy module 
 	"""
+
+	if serial_port == None:
+		serial_port = find_momo_serial()
+		if serial_port == None:
+			raise InitializationException( "No port specified and no valid USB device detected." )
 
 	s = transport.SerialTransport(serial_port)
 	c = cmdstream.CMDStream(s)
 
 	con = MIBController(c)
 	return con
+
+def find_momo_serial():
+	"""
+	Iterate over all connected COM devices and return the first
+	one that matches FTDI's Vendor ID (403)
+	"""
+	for port, desc, hwid in sorted( list_ports.comports() ):
+		if re.match( r"USB VID:PID=403:(\d+).*", hwid) != None:
+			continue
+		else:
+			return port


### PR DESCRIPTION
By default get_controller will connect to the first attached USB COMM device with a Vendor ID matching the FTDI chip (403). Potential future enhancements: Also match the Product ID, modify the VID/PID of the chip so that it is definitely a MoMo (this would require a custom driver).
