### PR TITLE
Make the leading 0 optional when matching USB Vendor ID

### DIFF
--- a/tools/bin/modtool.py
+++ b/tools/bin/modtool.py
@@ -255,6 +255,14 @@ class ModTool(cmdln.Cmdln):
 	def _get_controller(self, opts):
 		try:
 			c = get_controller(opts.port)
+		except NoSerialConnectionException as e:
+			print "Available serial ports:"
+			if not e.available_ports():
+				print "<none>"
+			else:
+				for port, desc, hwid in e.available_ports():
+					print "\t%s (%s, %s)" % ( port, desc, hwid )
+			self.error(str(e))
 		except ValueError as e:
 			self.error(str(e))
 

--- a/tools/pymomo/commander/exceptions.py
+++ b/tools/pymomo/commander/exceptions.py
@@ -10,9 +10,13 @@ class RPCException:
 		self.type = type
 		self.data = data
 
-class InitializationException:
-	def __init__(self, description):
-		self.message = description
+class NoSerialConnectionException:
+	def __init__(self, ports ):
+		self.message = "No port specified and no valid USB device detected."
+		self.ports = ports
 
 	def __str__(self):
 		return self.message
+
+	def available_ports(self):
+		return self.ports

--- a/tools/pymomo/commander/meta/initialization.py
+++ b/tools/pymomo/commander/meta/initialization.py
@@ -30,5 +30,6 @@ def find_momo_serial():
 	"""
 
 	for port, desc, hwid in sorted( list_ports.comports() ):
-		if (re.match( r"USB VID:PID=0403:(\d+).*", hwid) != None) or (re.match( r".*VID_0403.PID_6015", hwid) != None):
+		print port, desc, hwid
+		if (re.match( r"USB VID:PID=0?403:6015", hwid) != None) or (re.match( r".*VID_0?403.PID_6015", hwid) != None):
 			return port

--- a/tools/pymomo/commander/meta/initialization.py
+++ b/tools/pymomo/commander/meta/initialization.py
@@ -13,9 +13,9 @@ def get_controller(serial_port=None):
 	"""
 
 	if serial_port == None:
-		serial_port = find_momo_serial()
+		serial_port = _find_momo_serial()
 		if serial_port == None:
-			raise InitializationException( "No port specified and no valid USB device detected." )
+			raise NoSerialConnectionException( _get_serial_ports() )
 
 	s = transport.SerialTransport(serial_port)
 	c = cmdstream.CMDStream(s)
@@ -23,13 +23,15 @@ def get_controller(serial_port=None):
 	con = MIBController(c)
 	return con
 
-def find_momo_serial():
+def _get_serial_ports():
+	return list_ports.comports()
+
+def _find_momo_serial():
 	"""
 	Iterate over all connected COM devices and return the first
 	one that matches FTDI's Vendor ID (403)
 	"""
 
-	for port, desc, hwid in sorted( list_ports.comports() ):
-		print port, desc, hwid
+	for port, desc, hwid in _get_serial_ports():
 		if (re.match( r"USB VID:PID=0?403:6015", hwid) != None) or (re.match( r".*VID_0?403.PID_6015", hwid) != None):
 			return port


### PR DESCRIPTION
My FSU reports 403 without the leading 0, this allows for either case to match.

Also added some more informative error reporting and a list of available ports if none are found.
