### PR TITLE
Update MoMo FSU with Modular Connector

### DIFF
--- a/pcb/library/components.lbr
+++ b/pcb/library/components.lbr
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.4">
+<eagle version="6.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
@@ -37,7 +37,7 @@
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
-<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="yes" active="yes"/>
@@ -3227,6 +3227,42 @@ package type TQ</description>
 <wire x1="-3" y1="8.25" x2="-3" y2="6.25" width="0.254" layer="21"/>
 <wire x1="-3" y1="8.25" x2="3" y2="8.25" width="0.254" layer="21"/>
 <text x="3" y="-2" size="1.27" layer="21" rot="R180">&gt;NAME</text>
+</package>
+<package name="USB-MALE-EDGE">
+<description>Male USB-A port mounted on the edge of PCB. Molex part number 48037-2000</description>
+<wire x1="-5.7" y1="-1" x2="5.7" y2="-1" width="0.254" layer="21"/>
+<pad name="P$1" x="-5.7" y="1.75" drill="2.4"/>
+<pad name="P$2" x="5.7" y="1.75" drill="2.4"/>
+<pad name="P$3" x="-2.25" y="1.75" drill="1.17"/>
+<pad name="P$4" x="2.25" y="1.75" drill="1.17"/>
+<smd name="4" x="-3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="1" x="3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="2" x="1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="3" x="-1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<wire x1="-6" y1="-1" x2="-6" y2="5" width="0.254" layer="49"/>
+<wire x1="-6" y1="5" x2="6" y2="5" width="0.254" layer="49"/>
+<wire x1="6" y1="5" x2="6" y2="-1" width="0.254" layer="49"/>
+<wire x1="6" y1="-1" x2="-6" y2="-1" width="0.254" layer="49"/>
+<wire x1="-6" y1="-1" x2="-6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="-6" y1="-15.8" x2="6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="6" y1="-15.8" x2="6" y2="-1" width="0.254" layer="49"/>
+<text x="-2" y="0" size="0.8128" layer="49">&gt;NAME</text>
+</package>
+<package name="RJ12-VERT">
+<description>Vertical RJ-12 Connector, digikey pn: AE10391-ND</description>
+<pad name="ANCHOR1" x="-5.08" y="0" drill="3.27"/>
+<pad name="ARCHOR2" x="5.08" y="0" drill="3.27"/>
+<pad name="3" x="-0.635" y="8.89" drill="1.17"/>
+<pad name="1" x="-3.175" y="8.89" drill="1.17"/>
+<pad name="5" x="1.905" y="8.89" drill="1.17"/>
+<pad name="6" x="3.175" y="6.35" drill="1.17"/>
+<pad name="4" x="0.635" y="6.35" drill="1.17"/>
+<pad name="2" x="-1.905" y="6.35" drill="1.17"/>
+<wire x1="-7.95" y1="-6.48" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="7.95" y2="10.02" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="-7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="7.95" y1="10.02" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<text x="3" y="-5" size="0.8128" layer="21">&gt;NAME</text>
 </package>
 </packages>
 <symbols>
@@ -6429,6 +6465,52 @@ package type TQ</description>
 <attribute name="DESCRIPTION" value="R/A Shrouded 2 pin connector" constant="no"/>
 <attribute name="DIGIKEY-PN" value="455-1719-ND" constant="no"/>
 <attribute name="FOOTPRINT" value="Through HOle" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MOLEX-USB-CONN" prefix="JP">
+<gates>
+<gate name="G$1" symbol="USB-A" x="-2.54" y="-5.08"/>
+</gates>
+<devices>
+<device name="" package="USB-MALE-EDGE">
+<connects>
+<connect gate="G$1" pin="D+" pad="3"/>
+<connect gate="G$1" pin="D-" pad="2"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DESCRIPTION" value="USB-A Male Connector PCB Edge Mount" constant="no"/>
+<attribute name="DIGIKEY-PN" value="WM17118-ND" constant="no"/>
+<attribute name="FOOTPRINT" value="SMD + Through Hole" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MOMO-SENSOR-RJ11-VERT" prefix="JP">
+<gates>
+<gate name="G$1" symbol="MOMO-SENSOR-HEADER" x="-2.54" y="2.54"/>
+</gates>
+<devices>
+<device name="" package="RJ12-VERT">
+<connects>
+<connect gate="G$1" pin="2.8V" pad="1"/>
+<connect gate="G$1" pin="ALARM" pad="4"/>
+<connect gate="G$1" pin="CLK" pad="2"/>
+<connect gate="G$1" pin="DATA" pad="3"/>
+<connect gate="G$1" pin="GND" pad="5"/>
+<connect gate="G$1" pin="VBAT" pad="6"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DESCRIPTION" value="Vertical Mount RJ-12 Receptacle" constant="no"/>
+<attribute name="DIGIKEY-PN" value="AE10391-ND" constant="no"/>
+<attribute name="FOOTPRINT" value="Through Hole" constant="no"/>
 </technology>
 </technologies>
 </device>

--- a/pcb/programming_board/programming_board.brd
+++ b/pcb/programming_board/programming_board.brd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.4">
+<eagle version="6.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.001" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.025" altunitdist="inch" altunit="inch"/>
+<grid distance="0.004" unitdist="inch" unit="inch" style="dots" multiple="1" display="yes" altdistance="0.006" altunitdist="inch" altunit="inch"/>
 <layers>
-<layer number="1" name="Top" color="4" fill="1" visible="no" active="yes"/>
-<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="yes"/>
-<layer number="17" name="Pads" color="2" fill="1" visible="no" active="yes"/>
-<layer number="18" name="Vias" color="2" fill="1" visible="no" active="yes"/>
-<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="yes"/>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="22" name="bPlace" color="7" fill="1" visible="no" active="yes"/>
-<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
@@ -38,7 +38,7 @@
 <layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
 <layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
-<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
@@ -56,24 +56,12 @@
 </layers>
 <board>
 <plain>
-<text x="60.5536" y="56.007" size="1.016" layer="21" rot="R180">Onboard</text>
-<text x="83.2104" y="36.2204" size="1.016" layer="21" rot="R90">Momo ICP</text>
-<text x="35.052" y="23.9014" size="1.016" layer="21">Momo Field Service Unit v2</text>
-<text x="35.052" y="25.5524" size="1.016" layer="21">WellDone</text>
-<wire x1="29.5402" y1="21.971" x2="81.5594" y2="21.971" width="0.2032" layer="20"/>
-<wire x1="81.6102" y1="57.4294" x2="29.5148" y2="57.404" width="0.2032" layer="20"/>
-<wire x1="26.6192" y1="24.8412" x2="26.6192" y2="54.5338" width="0.2032" layer="20"/>
-<wire x1="84.5058" y1="24.892" x2="84.5058" y2="54.5592" width="0.2032" layer="20"/>
-<wire x1="26.6192" y1="54.5338" x2="29.5021" y2="57.404" width="0.2032" layer="20"/>
-<wire x1="81.5594" y1="21.971" x2="84.4423" y2="24.8412" width="0.2032" layer="20"/>
-<wire x1="29.5148" y1="21.971" x2="26.6319" y2="24.8412" width="0.2032" layer="20"/>
-<wire x1="84.4804" y1="54.5592" x2="81.5975" y2="57.4294" width="0.2032" layer="20"/>
-<hole x="31.5976" y="26.9748" drill="3.2512"/>
-<hole x="79.2226" y="52.3748" drill="3.2512"/>
-<text x="29.591" y="52.197" size="1.016" layer="21">Power</text>
-<text x="77.089" y="23.368" size="1.016" layer="21">Device</text>
-<dimension x1="26.6192" y1="54.5338" x2="84.5058" y2="54.5592" x3="55.56024375" y3="59.6860125" textsize="1.778" layer="49" unit="inch" visible="yes"/>
-<dimension x1="29.5402" y1="21.971" x2="29.5148" y2="57.404" x3="21.7296125" y3="39.681909375" textsize="1.778" layer="49" unit="inch" visible="yes"/>
+<wire x1="37.9984" y1="37.9984" x2="37.9984" y2="56.9976" width="0.254" layer="20"/>
+<wire x1="37.9984" y1="56.9976" x2="83.0072" y2="56.9976" width="0.254" layer="20"/>
+<wire x1="37.9984" y1="37.9984" x2="83.0072" y2="37.9984" width="0.254" layer="20"/>
+<wire x1="83.0072" y1="37.9984" x2="83.0072" y2="56.9976" width="0.254" layer="20"/>
+<dimension x1="37.9984" y1="56.9976" x2="83.0072" y2="56.9976" x3="60.5028" y3="61.4426" textsize="1.778" layer="49" dtype="vertical" unit="inch" precision="3"/>
+<dimension x1="83.0072" y1="37.9984" x2="83.0072" y2="56.9976" x3="88.0364" y3="47.498" textsize="1.778" layer="49" dtype="vertical" unit="inch" precision="3"/>
 </plain>
 <libraries>
 <library name="components">
@@ -149,26 +137,26 @@ CAD and Schematic files for the PIC24Fka101 series of microcontrollers.</descrip
 <wire x1="3.366" y1="2.286" x2="-3.365" y2="2.286" width="0.0508" layer="21"/>
 <wire x1="-3.365" y1="-2.286" x2="-3.365" y2="2.286" width="0.0508" layer="21"/>
 <circle x="-2.349" y="-1.397" radius="0.635" width="0.1524" layer="21"/>
-<smd name="1" x="-2.857" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="2" x="-2.222" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="3" x="-1.587" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="4" x="-0.952" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="5" x="-0.317" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="6" x="0.318" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="7" x="0.953" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="8" x="1.588" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="9" x="2.223" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="10" x="2.858" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="20" x="-2.857" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="19" x="-2.222" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="18" x="-1.587" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="17" x="-0.952" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="16" x="-0.317" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="15" x="0.318" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="14" x="0.953" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="13" x="1.588" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="12" x="2.223" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="11" x="2.858" y="3.302" dx="0.305" dy="1.245" layer="1"/>
+<smd name="1" x="-2.857" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="2" x="-2.222" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="3" x="-1.587" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="4" x="-0.952" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="5" x="-0.317" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="6" x="0.318" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="7" x="0.953" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="8" x="1.588" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="9" x="2.223" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="10" x="2.858" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="20" x="-2.857" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="19" x="-2.222" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="18" x="-1.587" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="17" x="-0.952" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="16" x="-0.317" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="15" x="0.318" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="14" x="0.953" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="13" x="1.588" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="12" x="2.219" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="11" x="2.858" y="3.431" dx="0.3" dy="1.5" layer="1"/>
 <text x="-4.064" y="-2.1204" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
 <text x="-2.7554" y="-0.0254" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="2.7564" y1="2.5908" x2="2.9596" y2="3.429" layer="51"/>
@@ -213,35 +201,41 @@ reflow soldering</description>
 <rectangle x1="-1.1684" y1="-1.2954" x2="-0.7112" y2="-0.7112" layer="51"/>
 <rectangle x1="-0.5001" y1="-0.3" x2="0.5001" y2="0.3" layer="35"/>
 </package>
-<package name="2X3-MOLEX-90130">
-<pad name="1" x="-2.54" y="2.54" drill="1"/>
-<pad name="2" x="0" y="2.54" drill="1"/>
-<pad name="3" x="2.54" y="2.54" drill="1"/>
-<pad name="6" x="2.54" y="0" drill="1"/>
-<pad name="5" x="0" y="0" drill="1"/>
-<pad name="4" x="-2.54" y="0" drill="1"/>
-<text x="0.635" y="4.445" size="0.8128" layer="25">&gt;NAME</text>
-<wire x1="4.9784" y1="-3.2766" x2="4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="-3.2766" x2="-4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="5.8166" x2="4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="-3.2766" x2="4.9784" y2="-3.2766" width="0.127" layer="21"/>
-<wire x1="-1.27" y1="-3.175" x2="-1.27" y2="-4.445" width="0.127" layer="21"/>
-<wire x1="-1.27" y1="-4.445" x2="1.27" y2="-4.445" width="0.127" layer="21"/>
-<wire x1="1.27" y1="-4.445" x2="1.27" y2="-3.175" width="0.127" layer="21"/>
-<wire x1="1.27" y1="-3.175" x2="-1.27" y2="-3.175" width="0.127" layer="21"/>
+<package name="USB-MALE-EDGE">
+<description>Male USB-A port mounted on the edge of PCB. Molex part number 48037-2000</description>
+<wire x1="-5.7" y1="-1" x2="5.7" y2="-1" width="0.254" layer="21"/>
+<pad name="P$1" x="-5.7" y="1.75" drill="2.4"/>
+<pad name="P$2" x="5.7" y="1.75" drill="2.4"/>
+<pad name="P$3" x="-2.25" y="1.75" drill="1.17"/>
+<pad name="P$4" x="2.25" y="1.75" drill="1.17"/>
+<smd name="4" x="-3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="1" x="3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="2" x="1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="3" x="-1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<wire x1="-6" y1="-1" x2="-6" y2="5" width="0.254" layer="49"/>
+<wire x1="-6" y1="5" x2="6" y2="5" width="0.254" layer="49"/>
+<wire x1="6" y1="5" x2="6" y2="-1" width="0.254" layer="49"/>
+<wire x1="6" y1="-1" x2="-6" y2="-1" width="0.254" layer="49"/>
+<wire x1="-6" y1="-1" x2="-6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="-6" y1="-15.8" x2="6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="6" y1="-15.8" x2="6" y2="-1" width="0.254" layer="49"/>
+<text x="-2" y="0" size="0.8128" layer="49">&gt;NAME</text>
 </package>
-<package name="USB-A">
-<smd name="VBUS" x="-3.5" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="D-" x="-1" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="D+" x="1" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="GND" x="3.5" y="0" dx="0.8" dy="2.82" layer="1"/>
-<pad name="P$5" x="-6.57" y="-3.71" drill="2.3" diameter="2.3"/>
-<pad name="P$6" x="6.57" y="-3.71" drill="2.3" diameter="2.3"/>
-<wire x1="-6.5" y1="1.2" x2="6.6" y2="1.2" width="0.127" layer="21"/>
-<wire x1="6.6" y1="1.2" x2="6.6" y2="-15" width="0.127" layer="21"/>
-<wire x1="6.6" y1="-15" x2="-6.5" y2="-15" width="0.127" layer="21"/>
-<wire x1="-6.5" y1="-15" x2="-6.5" y2="1.2" width="0.127" layer="21"/>
-<text x="0" y="-14.5" size="1.27" layer="25">&gt;NAME</text>
+<package name="RJ12-VERT">
+<description>Vertical RJ-12 Connector, digikey pn: AE10391-ND</description>
+<pad name="ANCHOR1" x="-5.08" y="0" drill="3.27"/>
+<pad name="ARCHOR2" x="5.08" y="0" drill="3.27"/>
+<pad name="3" x="-0.635" y="8.89" drill="1.17"/>
+<pad name="1" x="-3.175" y="8.89" drill="1.17"/>
+<pad name="5" x="1.905" y="8.89" drill="1.17"/>
+<pad name="6" x="3.175" y="6.35" drill="1.17"/>
+<pad name="4" x="0.635" y="6.35" drill="1.17"/>
+<pad name="2" x="-1.905" y="6.35" drill="1.17"/>
+<wire x1="-7.95" y1="-6.48" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="7.95" y2="10.02" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="-7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="7.95" y1="10.02" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<text x="3" y="-5" size="0.8128" layer="21">&gt;NAME</text>
 </package>
 </packages>
 </library>
@@ -1344,86 +1338,105 @@ for trimmer refence see : &lt;u&gt;www.electrospec-inc.com/cross_references/trim
 </package>
 </packages>
 </library>
-<library name="pinhead">
-<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
-&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
-<packages>
-<package name="1X06/90">
-<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
-<wire x1="-7.62" y1="-1.905" x2="-5.08" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="-1.905" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="0.635" x2="-7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-7.62" y1="0.635" x2="-7.62" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-6.35" y1="6.985" x2="-6.35" y2="1.27" width="0.762" layer="21"/>
-<wire x1="-5.08" y1="-1.905" x2="-2.54" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="-1.905" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-3.81" y1="6.985" x2="-3.81" y2="1.27" width="0.762" layer="21"/>
-<wire x1="-2.54" y1="-1.905" x2="0" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="0" y1="-1.905" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="0" y1="0.635" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-1.27" y1="6.985" x2="-1.27" y2="1.27" width="0.762" layer="21"/>
-<wire x1="0" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="1.27" y1="6.985" x2="1.27" y2="1.27" width="0.762" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="5.08" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="-1.905" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="0.635" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="3.81" y1="6.985" x2="3.81" y2="1.27" width="0.762" layer="21"/>
-<wire x1="5.08" y1="-1.905" x2="7.62" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="-1.905" x2="7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="0.635" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="6.35" y1="6.985" x2="6.35" y2="1.27" width="0.762" layer="21"/>
-<pad name="1" x="-6.35" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="2" x="-3.81" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="3" x="-1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="4" x="1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="5" x="3.81" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="6" x="6.35" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<text x="-8.255" y="-3.81" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
-<text x="9.525" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
-<rectangle x1="-6.731" y1="0.635" x2="-5.969" y2="1.143" layer="21"/>
-<rectangle x1="-4.191" y1="0.635" x2="-3.429" y2="1.143" layer="21"/>
-<rectangle x1="-1.651" y1="0.635" x2="-0.889" y2="1.143" layer="21"/>
-<rectangle x1="0.889" y1="0.635" x2="1.651" y2="1.143" layer="21"/>
-<rectangle x1="3.429" y1="0.635" x2="4.191" y2="1.143" layer="21"/>
-<rectangle x1="5.969" y1="0.635" x2="6.731" y2="1.143" layer="21"/>
-<rectangle x1="-6.731" y1="-2.921" x2="-5.969" y2="-1.905" layer="21"/>
-<rectangle x1="-4.191" y1="-2.921" x2="-3.429" y2="-1.905" layer="21"/>
-<rectangle x1="-1.651" y1="-2.921" x2="-0.889" y2="-1.905" layer="21"/>
-<rectangle x1="0.889" y1="-2.921" x2="1.651" y2="-1.905" layer="21"/>
-<rectangle x1="3.429" y1="-2.921" x2="4.191" y2="-1.905" layer="21"/>
-<rectangle x1="5.969" y1="-2.921" x2="6.731" y2="-1.905" layer="21"/>
-</package>
-</packages>
-</library>
 <library name="led">
 <description>&lt;b&gt;LEDs&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;&lt;br&gt;
 Extended by Federico Battaglin &lt;author&gt;&amp;lt;federico.rd@fdpinternational.com&amp;gt;&lt;/author&gt; with DUOLED</description>
 <packages>
-<package name="LED5MM">
-<description>&lt;B&gt;LED&lt;/B&gt;&lt;p&gt;
-5 mm, round</description>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.2032" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="1.905" width="0.254" layer="21" curve="-286.260205"/>
-<wire x1="-1.143" y1="0" x2="0" y2="1.143" width="0.1524" layer="51" curve="-90"/>
-<wire x1="0" y1="-1.143" x2="1.143" y2="0" width="0.1524" layer="51" curve="90"/>
-<wire x1="-1.651" y1="0" x2="0" y2="1.651" width="0.1524" layer="51" curve="-90"/>
-<wire x1="0" y1="-1.651" x2="1.651" y2="0" width="0.1524" layer="51" curve="90"/>
-<wire x1="-2.159" y1="0" x2="0" y2="2.159" width="0.1524" layer="51" curve="-90"/>
-<wire x1="0" y1="-2.159" x2="2.159" y2="0" width="0.1524" layer="51" curve="90"/>
-<circle x="0" y="0" radius="2.54" width="0.1524" layer="21"/>
-<pad name="A" x="-1.27" y="0" drill="0.8128" shape="octagon"/>
-<pad name="K" x="1.27" y="0" drill="0.8128" shape="octagon"/>
-<text x="3.175" y="0.5334" size="1.27" layer="25" ratio="10">&gt;NAME</text>
-<text x="3.2004" y="-1.8034" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<package name="SML0603">
+<description>&lt;b&gt;SML0603-XXX (HIGH INTENSITY) LED&lt;/b&gt;&lt;p&gt;
+&lt;table&gt;
+&lt;tr&gt;&lt;td&gt;AG3K&lt;/td&gt;&lt;td&gt;AQUA GREEN&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;B1K&lt;/td&gt;&lt;td&gt;SUPER BLUE&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;R1K&lt;/td&gt;&lt;td&gt;SUPER RED&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;R3K&lt;/td&gt;&lt;td&gt;ULTRA RED&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;O3K&lt;/td&gt;&lt;td&gt;SUPER ORANGE&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;O3KH&lt;/td&gt;&lt;td&gt;SOFT ORANGE&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;Y3KH&lt;/td&gt;&lt;td&gt;SUPER YELLOW&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;Y3K&lt;/td&gt;&lt;td&gt;SUPER YELLOW&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;2CW&lt;/td&gt;&lt;td&gt;WHITE&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+Source: http://www.ledtronics.com/ds/smd-0603/Dstr0092.pdf</description>
+<wire x1="-0.75" y1="0.35" x2="0.75" y2="0.35" width="0.1016" layer="51"/>
+<wire x1="0.75" y1="0.35" x2="0.75" y2="-0.35" width="0.1016" layer="51"/>
+<wire x1="0.75" y1="-0.35" x2="-0.75" y2="-0.35" width="0.1016" layer="51"/>
+<wire x1="-0.75" y1="-0.35" x2="-0.75" y2="0.35" width="0.1016" layer="51"/>
+<wire x1="-0.45" y1="0.3" x2="-0.45" y2="-0.3" width="0.1016" layer="51"/>
+<wire x1="0.45" y1="0.3" x2="0.45" y2="-0.3" width="0.1016" layer="51"/>
+<wire x1="-0.2" y1="0.35" x2="0.2" y2="0.35" width="0.1016" layer="21"/>
+<wire x1="-0.2" y1="-0.35" x2="0.2" y2="-0.35" width="0.1016" layer="21"/>
+<smd name="C" x="-0.75" y="0" dx="0.8" dy="0.8" layer="1"/>
+<smd name="A" x="0.75" y="0" dx="0.8" dy="0.8" layer="1"/>
+<text x="-1" y="1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1" y="-2" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.4" y1="0.175" x2="0" y2="0.4" layer="51"/>
+<rectangle x1="-0.25" y1="0.175" x2="0" y2="0.4" layer="21"/>
+</package>
+</packages>
+</library>
+<library name="pinhead">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X05">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="1.27" x2="-4.445" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="1.27" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-0.635" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-1.27" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="0.635" x2="-6.35" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="1.27" x2="-6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="-0.635" x2="-5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="-1.27" x2="-5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="6.35" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="5" x="5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.4262" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-6.35" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<rectangle x1="-2.794" y1="-0.254" x2="-2.286" y2="0.254" layer="51"/>
+<rectangle x1="-5.334" y1="-0.254" x2="-4.826" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
 </package>
 </packages>
 </library>
 </libraries>
 <attributes>
+<attribute name="HEIGHT" value="0.748"/>
+<attribute name="PARTNAME" value="field-service-unit"/>
+<attribute name="REVISION" value="3.0"/>
+<attribute name="WIDTH" value="1.772"/>
 </attributes>
 <variantdefs>
 </variantdefs>
@@ -1460,7 +1473,7 @@ design rules under a new name.</description>
 <param name="mdSmdSmd" value="8mil"/>
 <param name="mdViaViaSameLayer" value="8mil"/>
 <param name="mnLayersViaInSmd" value="2"/>
-<param name="mdCopperDimension" value="40mil"/>
+<param name="mdCopperDimension" value="10mil"/>
 <param name="mdDrill" value="8mil"/>
 <param name="mdSmdStop" value="0mil"/>
 <param name="msWidth" value="6mil"/>
@@ -1608,123 +1621,140 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="U1" library="components" package="SSOP16" value="FTDI-230X" x="50.8" y="33.2994" smashed="yes" rot="R180">
-<attribute name="NAME" x="51.6324" y="33.513" size="1.016" layer="25" rot="R180"/>
-<attribute name="VALUE" x="46.706" y="35.6154" size="1.27" layer="27" rot="R270"/>
+<element name="U1" library="components" package="SSOP16" value="FTDI-230X" x="49.403" y="52.7304" smashed="yes" rot="R180">
+<attribute name="NAME" x="50.4894" y="53.706" size="0.8128" layer="25" rot="R180"/>
+<attribute name="VALUE" x="45.309" y="55.0464" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="768-1135-1-ND" x="49.403" y="52.7304" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="DESCRIPTION" value="FTDI-230X USB-Serial Adapter IC" x="49.403" y="52.7304" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="FOOTPRINT" value="SSOP16" x="49.403" y="52.7304" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="FB1" library="components" package="R0805" value="FERRITE" x="44.577" y="45.4914" smashed="yes" rot="R90">
-<attribute name="NAME" x="43.434" y="44.3738" size="1.016" layer="25" rot="R90"/>
-<attribute name="VALUE" x="47.117" y="44.8564" size="1.27" layer="27" rot="R90"/>
+<element name="FB1" library="components" package="R0805" value="FERRITE" x="45.593" y="43.0276" smashed="yes" rot="R270">
+<attribute name="NAME" x="44.45" y="44.8056" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="43.053" y="43.6626" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="240-2390-1-ND" x="45.593" y="43.0276" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DESCRIPTION" value="Ferrite Bead" x="45.593" y="43.0276" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="FOOTPRINT" value="SMD 0805" x="45.593" y="43.0276" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C1" library="rcl" package="C0402" value="10nF" x="43.815" y="48.5394" smashed="yes" rot="R180">
-<attribute name="NAME" x="42.545" y="49.0474" size="1.016" layer="25" rot="R180"/>
-<attribute name="VALUE" x="44.45" y="50.4444" size="1.27" layer="27" rot="R180"/>
+<element name="C1" library="rcl" package="C0402" value="10nF" x="49.6824" y="48.3108" smashed="yes">
+<attribute name="NAME" x="48.514" y="47.625" size="0.8128" layer="25" rot="R90"/>
+<attribute name="VALUE" x="49.0474" y="46.4058" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="1276-1499-1-ND" x="49.6824" y="48.3108" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C2" library="rcl" package="C0402" value="100nF" x="50.546" y="28.6004" smashed="yes">
-<attribute name="NAME" x="47.117" y="28.067" size="1.016" layer="25"/>
-<attribute name="VALUE" x="49.911" y="26.6954" size="1.27" layer="27"/>
+<element name="C2" library="rcl" package="C0402" value="100nF" x="49.6824" y="47.0916" smashed="yes">
+<attribute name="NAME" x="48.8442" y="45.6438" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="49.0474" y="45.1866" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND" x="49.6824" y="47.0916" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C3" library="rcl" package="C0805" value="4.7uF" x="48.26" y="42.6974" smashed="yes">
-<attribute name="NAME" x="44.3738" y="42.2402" size="1.016" layer="25"/>
-<attribute name="VALUE" x="46.99" y="40.1574" size="1.27" layer="27"/>
+<element name="C3" library="rcl" package="C0805" value="4.7uF" x="43.942" y="39.1414" smashed="yes">
+<attribute name="NAME" x="40.0558" y="38.6842" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="42.672" y="36.6014" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="445-1605-1-ND" x="43.942" y="39.1414" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C4" library="rcl" package="C0402" value="47pF" x="46.609" y="34.3154" smashed="yes" rot="R270">
-<attribute name="NAME" x="46.2026" y="32.512" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="44.704" y="34.9504" size="1.27" layer="27" rot="R270"/>
+<element name="C4" library="rcl" package="C0402" value="47pF" x="46.3296" y="47.7012" smashed="yes">
+<attribute name="NAME" x="46.863" y="49.022" size="0.8128" layer="25" rot="R180"/>
+<attribute name="VALUE" x="45.6946" y="45.7962" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="1276-1699-1-ND" x="46.3296" y="47.7012" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C5" library="rcl" package="C0402" value="47pF" x="44.958" y="34.3154" smashed="yes" rot="R270">
-<attribute name="NAME" x="44.4754" y="32.4612" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="43.053" y="34.9504" size="1.27" layer="27" rot="R270"/>
+<element name="C5" library="rcl" package="C0402" value="47pF" x="46.3296" y="46.482" smashed="yes">
+<attribute name="NAME" x="48.3616" y="45.5422" size="0.8128" layer="25" rot="R90"/>
+<attribute name="VALUE" x="45.6946" y="44.577" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="1276-1699-1-ND" x="46.3296" y="46.482" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R1" library="rcl" package="R0603" value="27R" x="45.847" y="37.1094" smashed="yes">
-<attribute name="NAME" x="42.672" y="36.6014" size="1.016" layer="25"/>
-<attribute name="VALUE" x="45.212" y="35.2044" size="1.27" layer="27"/>
+<element name="R1" library="rcl" package="R0603" value="27R" x="45.8724" y="50.5968" smashed="yes" rot="R270">
+<attribute name="NAME" x="45.2882" y="52.0954" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="43.9674" y="51.2318" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="P27.0HCT-ND" x="45.8724" y="50.5968" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R2" library="rcl" package="R0603" value="27R" x="45.847" y="39.2684" smashed="yes">
-<attribute name="NAME" x="42.545" y="38.7604" size="1.016" layer="25"/>
-<attribute name="VALUE" x="45.212" y="37.3634" size="1.27" layer="27"/>
+<element name="R2" library="rcl" package="R0603" value="27R" x="45.8724" y="54.864" smashed="yes" rot="R90">
+<attribute name="NAME" x="45.1358" y="54.6862" size="0.8128" layer="25" rot="R90"/>
+<attribute name="VALUE" x="47.7774" y="54.229" size="1.27" layer="27" rot="R90"/>
+<attribute name="DIGIKEY-PN" value="P27.0HCT-ND" x="45.8724" y="54.864" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="J2" library="pinhead" package="1X06/90" value="" x="68.58" y="55.9816" smashed="yes">
-<attribute name="NAME" x="75.819" y="55.9308" size="1.27" layer="25" ratio="10" rot="R180"/>
-<attribute name="VALUE" x="78.105" y="52.1716" size="1.27" layer="27" rot="R90"/>
+<element name="U3" library="components" package="SSOP20" value="PIC24F16KA101-X_PSSOP" x="55.753" y="42.7736" smashed="yes">
+<attribute name="NAME" x="56.7558" y="43.1038" size="0.8128" layer="25" ratio="10" rot="R180"/>
+<attribute name="VALUE" x="52.9976" y="42.7482" size="1.27" layer="27" ratio="10"/>
+<attribute name="DIGIKEY-PN" value="PIC24F16KA101-I/SS-ND" x="55.753" y="42.7736" size="1.778" layer="27" display="off"/>
+<attribute name="DESCRIPTION" value="PIC 24F16KA101 16-bit Microprocessor" x="55.753" y="42.7736" size="1.778" layer="27" display="off"/>
+<attribute name="FOOTPRINT" value="SSOP20" x="55.753" y="42.7736" size="1.778" layer="27" display="off"/>
 </element>
-<element name="U3" library="components" package="SSOP20" value="PIC24F16KA101-X_PSSOP" x="55.499" y="42.3164" smashed="yes">
-<attribute name="NAME" x="56.5018" y="42.6466" size="1.016" layer="25" ratio="10" rot="R180"/>
-<attribute name="VALUE" x="52.7436" y="42.291" size="1.27" layer="27" ratio="10"/>
+<element name="C6" library="rcl" package="C0402" value="100 nF" x="53.4416" y="47.879" smashed="yes">
+<attribute name="NAME" x="52.4764" y="48.5394" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="52.8066" y="45.974" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND" x="53.4416" y="47.879" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C6" library="rcl" package="C0402" value="100 nF" x="53.213" y="47.3964" smashed="yes">
-<attribute name="NAME" x="52.2478" y="48.0568" size="1.016" layer="25"/>
-<attribute name="VALUE" x="52.578" y="45.4914" size="1.27" layer="27"/>
+<element name="U2" library="components" package="SOT23" value="MCP1702" x="47.625" y="40.4114" smashed="yes" rot="R90">
+<attribute name="NAME" x="46.9646" y="43.434" size="0.8128" layer="25" rot="R270"/>
+<attribute name="VALUE" x="50.8" y="38.5064" size="1.27" layer="27" rot="R90"/>
+<attribute name="DESCRIPTION" value="MCP1702 2.8V Linear Regulator" x="47.625" y="40.4114" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY-PN" value="MCP1702T-2802E/CBCT-ND" x="47.625" y="40.4114" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="U2" library="components" package="SOT23" value="MCP1702" x="47.752" y="46.2534" smashed="yes" rot="R90">
-<attribute name="NAME" x="48.2854" y="47.879" size="1.016" layer="25" rot="R90"/>
-<attribute name="VALUE" x="50.927" y="44.3484" size="1.27" layer="27" rot="R90"/>
+<element name="C8" library="rcl" package="C0402" value="1 uF" x="50.292" y="40.4114" smashed="yes" rot="R270">
+<attribute name="NAME" x="51.054" y="40.6908" size="0.8128" layer="25" rot="R270"/>
+<attribute name="VALUE" x="48.387" y="41.0464" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="1276-1076-1-ND" x="50.292" y="40.4114" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C8" library="rcl" package="C0402" value="1 uF" x="50.546" y="46.2534" smashed="yes" rot="R270">
-<attribute name="NAME" x="50.038" y="49.7078" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="48.641" y="46.8884" size="1.27" layer="27" rot="R270"/>
+<element name="R4" library="rcl" package="R0603" value="10K" x="49.6316" y="42.926" smashed="yes" rot="R180">
+<attribute name="NAME" x="50.4698" y="44.8564" size="0.8128" layer="25" rot="R180"/>
+<attribute name="VALUE" x="50.2666" y="44.831" size="1.27" layer="27" rot="R180"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="49.6316" y="42.926" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="R4" library="rcl" package="R0603" value="10K" x="50.546" y="39.9034" smashed="yes" rot="R90">
-<attribute name="NAME" x="49.6824" y="38.5572" size="1.016" layer="25" rot="R90"/>
-<attribute name="VALUE" x="52.451" y="39.2684" size="1.27" layer="27" rot="R90"/>
+<element name="R6" library="rcl" package="R0603" value="10K" x="63.6778" y="48.641" smashed="yes">
+<attribute name="NAME" x="62.9158" y="47.0408" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="63.0428" y="46.736" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="63.6778" y="48.641" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R6" library="rcl" package="R0603" value="10K" x="69.977" y="42.1894" smashed="yes" rot="R270">
-<attribute name="NAME" x="69.4436" y="40.513" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="68.072" y="42.8244" size="1.27" layer="27" rot="R270"/>
+<element name="R7" library="rcl" package="R0603" value="10K" x="60.6552" y="48.641" smashed="yes">
+<attribute name="NAME" x="60.5028" y="47.0662" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="60.0202" y="46.736" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="60.6552" y="48.641" size="1.778" layer="27" display="off"/>
 </element>
-<element name="R7" library="rcl" package="R0603" value="10K" x="69.977" y="45.2374" smashed="yes" rot="R270">
-<attribute name="NAME" x="69.469" y="48.5902" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="68.072" y="45.8724" size="1.27" layer="27" rot="R270"/>
+<element name="C7" library="rcl" package="C0402" value="100nF" x="60.9092" y="50.0888" smashed="yes" rot="R180">
+<attribute name="NAME" x="61.722" y="51.6636" size="0.8128" layer="25" rot="R180"/>
+<attribute name="VALUE" x="61.5442" y="51.9938" size="1.27" layer="27" rot="R180"/>
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND" x="60.9092" y="50.0888" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
-<element name="R8" library="rcl" package="R0603" value="10K" x="67.818" y="45.2374" smashed="yes" rot="R270">
-<attribute name="NAME" x="67.3862" y="48.5648" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="65.913" y="45.8724" size="1.27" layer="27" rot="R270"/>
+<element name="R5" library="rcl" package="R0603" value="10K" x="62.3316" y="40.5384" smashed="yes" rot="R270">
+<attribute name="NAME" x="62.865" y="42.0116" size="0.8128" layer="25" rot="R90"/>
+<attribute name="VALUE" x="60.4266" y="41.1734" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="62.3316" y="40.5384" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R9" library="rcl" package="R0603" value="1K" x="67.818" y="42.1894" smashed="yes" rot="R270">
-<attribute name="NAME" x="67.3862" y="40.5892" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="65.913" y="42.8244" size="1.27" layer="27" rot="R270"/>
+<element name="R10" library="rcl" package="R0603" value="10K" x="64.1604" y="40.5384" smashed="yes" rot="R270">
+<attribute name="NAME" x="64.6176" y="41.9862" size="0.8128" layer="25" rot="R90"/>
+<attribute name="VALUE" x="62.2554" y="41.1734" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="64.1604" y="40.5384" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="C9" library="rcl" package="C0402" value="100 nF" x="55.245" y="49.4284" smashed="yes" rot="R90">
-<attribute name="NAME" x="54.7624" y="52.8828" size="1.016" layer="25" rot="R270"/>
-<attribute name="VALUE" x="57.15" y="48.7934" size="1.27" layer="27" rot="R90"/>
+<element name="R12" library="rcl" package="R0603" value="68R" x="64.1096" y="44.8818" smashed="yes">
+<attribute name="NAME" x="63.0936" y="45.72" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="63.4746" y="42.9768" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="P68GCT-ND" x="64.1096" y="44.8818" size="1.778" layer="27" display="off"/>
 </element>
-<element name="C7" library="rcl" package="C0402" value="100nF" x="56.642" y="49.4284" smashed="yes" rot="R90">
-<attribute name="NAME" x="57.15" y="51.054" size="1.016" layer="25" rot="R90"/>
-<attribute name="VALUE" x="58.547" y="48.7934" size="1.27" layer="27" rot="R90"/>
+<element name="R3" library="rcl" package="R0603" value="10K" x="60.5028" y="40.5384" smashed="yes" rot="R270">
+<attribute name="NAME" x="60.1472" y="43.5102" size="0.8128" layer="25" rot="R270"/>
+<attribute name="VALUE" x="58.5978" y="41.1734" size="1.27" layer="27" rot="R270"/>
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND" x="60.5028" y="40.5384" size="1.778" layer="27" rot="R270" display="off"/>
 </element>
-<element name="R5" library="rcl" package="R0603" value="10K" x="73.66" y="32.0294" smashed="yes" rot="R180">
-<attribute name="NAME" x="71.882" y="32.4104" size="1.016" layer="25" rot="R180"/>
-<attribute name="VALUE" x="74.295" y="33.9344" size="1.27" layer="27" rot="R180"/>
+<element name="JP1" library="components" package="USB-MALE-EDGE" value="MOLEX-USB-CONN" x="39.0144" y="47.498" smashed="yes" rot="R270">
+<attribute name="DESCRIPTION" value="USB-A Male Connector PCB Edge Mount" x="39.0144" y="47.498" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="FOOTPRINT" value="SMD + Through Hole" x="39.0144" y="47.498" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="DIGIKEY-PN" value="WM17118-ND" x="39.0144" y="47.498" size="1.778" layer="27" rot="R270" display="off"/>
+<attribute name="NAME" x="39.5036" y="47.0408" size="0.8128" layer="49"/>
 </element>
-<element name="R10" library="rcl" package="R0603" value="10K" x="75.3618" y="45.847" smashed="yes" rot="R180">
-<attribute name="NAME" x="74.2188" y="47.0662" size="1.016" layer="25"/>
-<attribute name="VALUE" x="75.9968" y="47.752" size="1.27" layer="27" rot="R180"/>
+<element name="LED2" library="led" package="SML0603" value="" x="61.3918" y="44.8564" smashed="yes">
+<attribute name="NAME" x="59.7822" y="45.704" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="60.3918" y="42.8564" size="1.27" layer="27"/>
+<attribute name="DIGIKEY-PN" value="475-1409-1-ND" x="61.3918" y="44.8564" size="1.778" layer="27" display="off"/>
+<attribute name="DESCRIPTION" value="Green Chip LED" x="61.3918" y="44.8564" size="1.778" layer="27" display="off"/>
+<attribute name="FOOTPRINT" value="SMD 0603" x="61.3918" y="44.8564" size="1.778" layer="27" display="off"/>
 </element>
-<element name="LED1" library="led" package="LED5MM" value="" x="36.449" y="52.578" smashed="yes" rot="R180">
-<attribute name="NAME" x="33.5534" y="51.5112" size="1.27" layer="25" ratio="10" rot="R180"/>
-<attribute name="VALUE" x="33.2486" y="54.3814" size="1.27" layer="27" ratio="10" rot="R180"/>
+<element name="JP3" library="components" package="RJ12-VERT" value="MOMO-SENSOR-RJ11-VERT" x="75.9714" y="47.498" rot="R90">
+<attribute name="DESCRIPTION" value="Vertical Mount RJ-12 Receptacle" x="75.9714" y="47.498" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="FOOTPRINT" value="Through Hole" x="75.9714" y="47.498" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="DIGIKEY-PN" value="AE10391-ND" x="75.9714" y="47.498" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
-<element name="R11" library="rcl" package="R0603" value="66R" x="42.291" y="52.578" smashed="yes">
-<attribute name="NAME" x="41.275" y="53.594" size="1.016" layer="25"/>
-<attribute name="VALUE" x="41.656" y="50.673" size="1.27" layer="27"/>
-</element>
-<element name="LED2" library="led" package="LED5MM" value="" x="79.375" y="27.813" smashed="yes">
-<attribute name="NAME" x="77.5716" y="31.3944" size="1.27" layer="25" ratio="10"/>
-<attribute name="VALUE" x="82.5754" y="26.0096" size="1.27" layer="27" ratio="10"/>
-</element>
-<element name="R12" library="rcl" package="R0603" value="66R" x="73.66" y="27.813" smashed="yes" rot="R180">
-<attribute name="NAME" x="71.882" y="28.3464" size="1.016" layer="25" rot="R180"/>
-<attribute name="VALUE" x="74.295" y="29.718" size="1.27" layer="27" rot="R180"/>
-</element>
-<element name="R3" library="rcl" package="R0603" value="10K" x="73.66" y="29.9212" smashed="yes" rot="R180">
-<attribute name="NAME" x="71.9074" y="30.4292" size="1.016" layer="25" rot="R180"/>
-<attribute name="VALUE" x="74.295" y="31.8262" size="1.27" layer="27" rot="R180"/>
-</element>
-<element name="J3" library="components" package="2X3-MOLEX-90130" value="MOMO-SENSOR-HEADER" x="77.47" y="39.624" smashed="yes" rot="R90">
-<attribute name="NAME" x="80.391" y="36.3728" size="1.27" layer="25" rot="R180"/>
-</element>
-<element name="USB1" library="components" package="USB-A" value="USB-A" x="40.513" y="39.6494" smashed="yes" rot="R270">
-<attribute name="NAME" x="31.5468" y="38.6114" size="1.27" layer="25"/>
+<element name="JP2" library="pinhead" package="1X05" value="" x="58.928" y="54.5338" smashed="yes" rot="R180">
+<attribute name="NAME" x="56.0578" y="52.8574" size="0.8128" layer="25" ratio="10" rot="R180"/>
+<attribute name="VALUE" x="65.278" y="57.7088" size="1.27" layer="27" rot="R180"/>
+<attribute name="POPULATE" value="NO" x="58.928" y="54.5338" size="1.778" layer="27" rot="R180" display="off"/>
 </element>
 </elements>
 <signals>
@@ -1740,104 +1770,61 @@ design rules under a new name.</description>
 <contactref element="U3" pad="19"/>
 <contactref element="U2" pad="1"/>
 <contactref element="C8" pad="2"/>
-<contactref element="J2" pad="4"/>
 <contactref element="R7" pad="1"/>
-<contactref element="R8" pad="1"/>
 <contactref element="C7" pad="2"/>
-<contactref element="C9" pad="2"/>
-<polygon width="0.4064" layer="16">
-<vertex x="26.289" y="60.9854"/>
-<vertex x="85.09" y="59.8424"/>
-<vertex x="84.963" y="21.8694"/>
-<vertex x="26.162" y="21.4884"/>
+<contactref element="JP1" pad="4"/>
+<contactref element="JP1" pad="4"/>
+<contactref element="LED2" pad="C"/>
+<contactref element="JP3" pad="5"/>
+<contactref element="JP2" pad="3"/>
+<wire x1="49.078" y1="55.6554" x2="49.078" y2="51.8108" width="0.1524" layer="1"/>
+<wire x1="49.078" y1="51.8108" x2="49.6824" y2="51.2064" width="0.1524" layer="1"/>
+<wire x1="49.6824" y1="51.2064" x2="49.6824" y2="49.851" width="0.1524" layer="1"/>
+<wire x1="49.6824" y1="49.851" x2="49.728" y2="49.8054" width="0.1524" layer="1"/>
+<via x="46.9392" y="45.2628" extent="1-16" drill="0.5"/>
+<wire x1="46.9796" y1="47.7012" x2="46.9796" y2="46.482" width="0.1524" layer="1"/>
+<wire x1="46.9796" y1="46.482" x2="46.9392" y2="46.34" width="0.1524" layer="1"/>
+<wire x1="46.9392" y1="46.34" x2="46.9392" y2="45.2628" width="0.1524" layer="1"/>
+<via x="51.3588" y="48.3108" extent="1-16" drill="0.5"/>
+<wire x1="50.3324" y1="48.3108" x2="51.3588" y2="48.3108" width="0.3048" layer="1"/>
+<via x="46.3296" y="39.0144" extent="1-16" drill="0.5"/>
+<wire x1="44.892" y1="39.1414" x2="44.892" y2="39.0144" width="0.3048" layer="1"/>
+<wire x1="44.892" y1="39.0144" x2="46.3296" y2="39.0144" width="0.3048" layer="1"/>
+<wire x1="46.3296" y1="39.0144" x2="46.3296" y2="39.4614" width="0.3048" layer="1"/>
+<wire x1="46.3296" y1="39.4614" x2="48.725" y2="39.4614" width="0.3048" layer="1"/>
+<wire x1="50.292" y1="39.7614" x2="50.292" y2="39.4614" width="0.3048" layer="1"/>
+<wire x1="50.292" y1="39.4614" x2="48.725" y2="39.4614" width="0.3048" layer="1"/>
+<wire x1="50.3324" y1="47.0916" x2="50.3324" y2="48.3108" width="0.3048" layer="1"/>
+<wire x1="50.3324" y1="48.3108" x2="49.728" y2="48.9152" width="0.3048" layer="1"/>
+<wire x1="49.728" y1="48.9152" x2="49.728" y2="49.8054" width="0.3048" layer="1"/>
+<via x="43.2816" y="52.2732" extent="1-16" drill="0.5"/>
+<wire x1="43.3644" y1="50.998" x2="43.3644" y2="52.2732" width="0.3048" layer="1"/>
+<wire x1="43.3644" y1="52.2732" x2="43.2816" y2="52.2732" width="0.3048" layer="1"/>
+<wire x1="53.531" y1="46.2046" x2="53.531" y2="47.166" width="0.3048" layer="1"/>
+<wire x1="53.531" y1="47.166" x2="54.0916" y2="47.879" width="0.3048" layer="1"/>
+<via x="53.7972" y="44.5008" extent="1-16" drill="0.5"/>
+<wire x1="53.7972" y1="44.5008" x2="53.531" y2="44.767" width="0.3048" layer="1"/>
+<wire x1="53.531" y1="44.767" x2="53.531" y2="46.2046" width="0.3048" layer="1"/>
+<via x="59.436" y="44.8056" extent="1-16" drill="0.5"/>
+<wire x1="60.6418" y1="44.8564" x2="60.4386" y2="44.8056" width="0.3048" layer="1"/>
+<wire x1="60.4386" y1="44.8056" x2="59.436" y2="44.8056" width="0.3048" layer="1"/>
+<wire x1="59.8052" y1="48.641" x2="59.8052" y2="49.6348" width="0.1524" layer="1"/>
+<wire x1="59.8052" y1="49.6348" x2="60.2592" y2="50.0888" width="0.1524" layer="1"/>
+<via x="59.5884" y="47.3964" extent="1-16" drill="0.5"/>
+<wire x1="59.8052" y1="48.641" x2="59.5884" y2="48.4242" width="0.1524" layer="1"/>
+<wire x1="59.5884" y1="48.4242" x2="59.5884" y2="47.3964" width="0.1524" layer="1"/>
+<polygon width="0.1524" layer="16">
+<vertex x="37.9476" y="56.9976"/>
+<vertex x="83.058" y="56.9976"/>
+<vertex x="83.058" y="37.9476"/>
+<vertex x="37.9476" y="37.9476"/>
 </polygon>
-<wire x1="50.546" y1="45.6184" x2="50.546" y2="45.6034" width="0.2032" layer="1"/>
-<wire x1="50.419" y1="36.4744" x2="50.475" y2="36.2244" width="0.2032" layer="1"/>
-<via x="52.197" y="27.8384" extent="1-16" drill="0.4826"/>
-<wire x1="53.277" y1="45.6184" x2="53.277" y2="46.8104" width="0.3048" layer="1"/>
-<wire x1="53.277" y1="46.8104" x2="53.863" y2="47.3964" width="0.3048" layer="1"/>
-<wire x1="55.245" y1="50.0784" x2="56.642" y2="50.0784" width="0.3048" layer="1"/>
-<via x="71.247" y="45.9994" extent="1-16" drill="0.5"/>
-<wire x1="81.407" y1="49.149" x2="81.407" y2="42.0624" width="0.3048" layer="16"/>
-<wire x1="81.407" y1="42.0624" x2="81.153" y2="42.0624" width="0.3048" layer="16"/>
-<wire x1="81.28" y1="42.0624" x2="81.153" y2="42.0624" width="0.2032" layer="16"/>
-<wire x1="44.958" y1="33.6654" x2="46.609" y2="33.6654" width="0.4064" layer="1"/>
-<wire x1="71.247" y1="45.9994" x2="69.977" y2="45.9994" width="0.2032" layer="1"/>
-<wire x1="69.977" y1="45.9994" x2="69.977" y2="46.0874" width="0.2032" layer="1"/>
-<wire x1="67.818" y1="46.0874" x2="69.977" y2="46.0874" width="0.2032" layer="1"/>
-<wire x1="71.12" y1="46.1264" x2="71.247" y2="45.9994" width="0.2032" layer="16"/>
-<wire x1="51.125" y1="30.3744" x2="51.125" y2="28.6004" width="0.4064" layer="1"/>
-<wire x1="51.125" y1="28.6004" x2="51.196" y2="28.6004" width="0.4064" layer="1"/>
-<wire x1="69.85" y1="49.276" x2="81.407" y2="49.149" width="0.2032" layer="16"/>
-<wire x1="69.85" y1="49.276" x2="69.85" y2="52.1716" width="0.2032" layer="16"/>
-<contactref element="LED1" pad="K"/>
-<contactref element="LED2" pad="K"/>
-<contactref element="J3" pad="6"/>
-<contactref element="USB1" pad="GND"/>
-<contactref element="USB1" pad="GND"/>
-<via x="50.546" y="44.2214" extent="1-16" drill="0.5"/>
-<via x="50.546" y="43.0022" extent="1-16" drill="0.5"/>
-<wire x1="50.546" y1="44.2214" x2="50.546" y2="45.6034" width="0.4064" layer="1"/>
-<wire x1="50.546" y1="45.6034" x2="50.246" y2="45.3034" width="0.4064" layer="1"/>
-<wire x1="50.246" y1="45.3034" x2="48.852" y2="45.3034" width="0.4064" layer="1"/>
-<wire x1="49.21" y1="42.6974" x2="49.2862" y2="42.7736" width="0.4064" layer="1"/>
-<wire x1="49.2862" y1="42.7736" x2="49.3522" y2="42.7736" width="0.4064" layer="1"/>
-<wire x1="49.3522" y1="42.7736" x2="49.5808" y2="43.0022" width="0.4064" layer="1"/>
-<wire x1="49.5808" y1="43.0022" x2="50.546" y2="43.0022" width="0.4064" layer="1"/>
-<wire x1="50.546" y1="44.2214" x2="45.8978" y2="44.2214" width="0.3048" layer="16"/>
-<wire x1="45.8978" y1="44.2214" x2="45.8978" y2="49.7586" width="0.3048" layer="16"/>
-<wire x1="45.8978" y1="49.7586" x2="41.91" y2="49.7586" width="0.3048" layer="16"/>
-<wire x1="41.91" y1="49.7586" x2="35.179" y2="49.7586" width="0.3048" layer="16"/>
-<wire x1="35.179" y1="49.7586" x2="35.179" y2="52.578" width="0.3048" layer="16"/>
-<via x="43.1038" y="49.784" extent="1-16" drill="0.5"/>
-<wire x1="43.165" y1="48.5394" x2="43.1038" y2="48.5394" width="0.3048" layer="1"/>
-<wire x1="43.1038" y1="48.5394" x2="43.1038" y2="49.784" width="0.3048" layer="1"/>
-<wire x1="43.1038" y1="49.784" x2="41.9354" y2="49.784" width="0.3048" layer="16"/>
-<wire x1="41.9354" y1="49.784" x2="41.91" y2="49.7586" width="0.3048" layer="16"/>
-<wire x1="40.513" y1="36.1494" x2="42.997" y2="33.6654" width="0.6096" layer="1"/>
-<wire x1="42.997" y1="33.6654" x2="43.4086" y2="33.6654" width="0.6096" layer="1"/>
-<via x="50.4698" y="34.671" extent="1-16" drill="0.4826"/>
-<wire x1="43.4086" y1="33.6654" x2="44.958" y2="33.6654" width="0.6096" layer="1"/>
-<wire x1="50.4698" y1="34.671" x2="52.197" y2="32.9438" width="0.3048" layer="16"/>
-<wire x1="52.197" y1="32.9438" x2="52.197" y2="27.8384" width="0.3048" layer="16"/>
-<wire x1="50.4698" y1="34.671" x2="50.475" y2="34.6762" width="0.3048" layer="1"/>
-<wire x1="50.475" y1="34.6762" x2="50.475" y2="36.2244" width="0.3048" layer="1"/>
-<via x="43.434" y="32.2326" extent="1-16" drill="0.4826"/>
-<via x="42.4942" y="32.258" extent="1-16" drill="0.4826"/>
-<wire x1="43.434" y1="32.2326" x2="43.4086" y2="32.258" width="0.3048" layer="1"/>
-<wire x1="43.4086" y1="32.258" x2="43.4086" y2="33.6654" width="0.3048" layer="1"/>
-<wire x1="43.4086" y1="32.258" x2="42.4942" y2="32.258" width="0.3048" layer="1"/>
-<wire x1="50.4698" y1="34.671" x2="48.0314" y2="32.2326" width="0.3048" layer="16"/>
-<wire x1="48.0314" y1="32.2326" x2="43.434" y2="32.2326" width="0.3048" layer="16"/>
-<wire x1="50.546" y1="43.0022" x2="50.4698" y2="42.926" width="0.3048" layer="16"/>
-<wire x1="50.4698" y1="42.926" x2="50.4698" y2="34.671" width="0.3048" layer="16"/>
-<wire x1="50.546" y1="43.0022" x2="50.546" y2="44.2214" width="0.3048" layer="1"/>
-<via x="53.9496" y="50.0634" extent="1-16" drill="0.5"/>
-<wire x1="53.9496" y1="50.0634" x2="53.9496" y2="49.784" width="0.3048" layer="16"/>
-<wire x1="53.9496" y1="49.784" x2="43.1038" y2="49.784" width="0.3048" layer="16"/>
-<wire x1="53.9496" y1="50.0634" x2="53.9496" y2="47.3964" width="0.3048" layer="1"/>
-<wire x1="53.9496" y1="47.3964" x2="53.863" y2="47.3964" width="0.3048" layer="1"/>
-<wire x1="53.9496" y1="50.0634" x2="53.9496" y2="50.0784" width="0.3048" layer="1"/>
-<wire x1="53.9496" y1="50.0784" x2="55.245" y2="50.0784" width="0.3048" layer="1"/>
-<wire x1="80.645" y1="27.813" x2="81.407" y2="28.575" width="0.254" layer="16"/>
-<wire x1="81.407" y1="28.575" x2="81.407" y2="42.0624" width="0.254" layer="16"/>
-<wire x1="81.153" y1="42.0624" x2="77.5716" y2="42.0624" width="0.3048" layer="16"/>
-<wire x1="77.5716" y1="42.0624" x2="77.47" y2="42.164" width="0.3048" layer="16"/>
-<wire x1="69.85" y1="49.276" x2="59.4614" y2="49.276" width="0.3048" layer="16"/>
-<wire x1="59.4614" y1="49.276" x2="57.531" y2="51.2064" width="0.3048" layer="16"/>
-<wire x1="57.531" y1="51.2064" x2="55.0926" y2="51.2064" width="0.3048" layer="16"/>
-<wire x1="55.0926" y1="51.2064" x2="53.9496" y2="50.0634" width="0.3048" layer="16"/>
-<wire x1="69.85" y1="49.276" x2="69.85" y2="48.2346" width="0.3048" layer="16"/>
-<wire x1="69.85" y1="48.2346" x2="71.247" y2="46.8376" width="0.3048" layer="16"/>
-<wire x1="71.247" y1="46.8376" x2="71.247" y2="45.9994" width="0.3048" layer="16"/>
-<wire x1="51.196" y1="28.6004" x2="51.435" y2="28.6004" width="0.3048" layer="1"/>
-<wire x1="51.435" y1="28.6004" x2="52.197" y2="27.8384" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$2">
 <contactref element="FB1" pad="1"/>
-<wire x1="40.513" y1="44.5414" x2="44.577" y2="44.5414" width="0.6096" layer="1"/>
-<contactref element="USB1" pad="VBUS"/>
-<wire x1="40.513" y1="44.5414" x2="40.513" y2="43.1494" width="0.6096" layer="1"/>
+<contactref element="JP1" pad="1"/>
+<wire x1="43.3644" y1="43.998" x2="43.3848" y2="43.9776" width="0.3048" layer="1"/>
+<wire x1="43.3848" y1="43.9776" x2="45.593" y2="43.9776" width="0.3048" layer="1"/>
 </signal>
 <signal name="+5V">
 <contactref element="FB1" pad="2"/>
@@ -1846,101 +1833,86 @@ design rules under a new name.</description>
 <contactref element="C3" pad="1"/>
 <contactref element="U1" pad="12"/>
 <contactref element="U2" pad="3"/>
-<wire x1="44.577" y1="46.4414" x2="44.897" y2="46.2534" width="1.016" layer="1"/>
-<wire x1="44.897" y1="46.2534" x2="46.652" y2="46.2534" width="1.016" layer="1"/>
-<wire x1="46.652" y1="46.2534" x2="47.31" y2="45.5954" width="0.6096" layer="1"/>
-<wire x1="47.31" y1="45.5954" x2="47.31" y2="42.6974" width="0.6096" layer="1"/>
-<wire x1="44.465" y1="48.5394" x2="44.577" y2="48.5394" width="0.2032" layer="1"/>
-<wire x1="44.577" y1="48.5394" x2="44.577" y2="46.4414" width="0.2032" layer="1"/>
-<wire x1="47.31" y1="42.6974" x2="46.4464" y2="41.8338" width="0.4064" layer="1"/>
-<wire x1="46.4464" y1="41.8338" x2="38.354" y2="41.8338" width="0.4064" layer="1"/>
-<wire x1="38.354" y1="41.8338" x2="38.354" y2="34.925" width="0.4064" layer="1"/>
-<wire x1="38.354" y1="34.925" x2="39.7256" y2="34.925" width="0.4064" layer="1"/>
-<wire x1="39.7256" y1="34.925" x2="41.4782" y2="33.1724" width="0.4064" layer="1"/>
-<wire x1="41.4782" y1="33.1724" x2="41.4782" y2="28.6004" width="0.4064" layer="1"/>
-<wire x1="41.4782" y1="28.6004" x2="49.896" y2="28.6004" width="0.4064" layer="1"/>
-<wire x1="50.475" y1="30.3744" x2="50.475" y2="29.4946" width="0.3048" layer="1"/>
-<wire x1="50.475" y1="29.4946" x2="49.896" y2="28.9156" width="0.3048" layer="1"/>
-<wire x1="49.896" y1="28.9156" x2="49.896" y2="28.6004" width="0.3048" layer="1"/>
+<wire x1="49.1086" y1="49.7748" x2="49.078" y2="49.8054" width="0.3048" layer="1"/>
+<wire x1="45.593" y1="42.0776" x2="45.72" y2="41.9506" width="0.3048" layer="1"/>
+<wire x1="45.72" y1="41.9506" x2="45.72" y2="40.5384" width="0.3048" layer="1"/>
+<wire x1="45.72" y1="40.5384" x2="45.7454" y2="40.4114" width="0.3048" layer="1"/>
+<wire x1="45.7454" y1="40.4114" x2="46.525" y2="40.4114" width="0.3048" layer="1"/>
+<wire x1="42.992" y1="39.1414" x2="42.992" y2="40.4114" width="0.3048" layer="1"/>
+<wire x1="42.992" y1="40.4114" x2="45.7454" y2="40.4114" width="0.3048" layer="1"/>
+<wire x1="49.1086" y1="49.7748" x2="49.1086" y2="48.3108" width="0.3048" layer="1"/>
+<wire x1="49.1086" y1="48.3108" x2="49.0324" y2="48.3108" width="0.3048" layer="1"/>
+<wire x1="49.0324" y1="48.3108" x2="49.0324" y2="47.0916" width="0.3048" layer="1"/>
+<wire x1="49.0324" y1="47.0916" x2="47.8536" y2="47.0916" width="0.3048" layer="1"/>
+<wire x1="47.8536" y1="47.0916" x2="47.8536" y2="44.3484" width="0.3048" layer="1"/>
+<wire x1="47.8536" y1="44.3484" x2="46.7868" y2="44.3484" width="0.3048" layer="1"/>
+<wire x1="46.7868" y1="44.3484" x2="46.7868" y2="42.0624" width="0.3048" layer="1"/>
+<wire x1="46.7868" y1="42.0624" x2="45.593" y2="42.0624" width="0.3048" layer="1"/>
+<wire x1="45.593" y1="42.0624" x2="45.593" y2="42.0776" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$3">
 <contactref element="R2" pad="1"/>
 <contactref element="C5" pad="1"/>
-<wire x1="44.069" y1="35.9664" x2="44.958" y2="35.0774" width="0.2032" layer="1"/>
-<wire x1="44.069" y1="38.3794" x2="44.069" y2="35.9664" width="0.2032" layer="1"/>
-<wire x1="44.958" y1="39.2684" x2="44.1325" y2="38.4429" width="0.2032" layer="1"/>
-<wire x1="44.1325" y1="38.4429" x2="44.069" y2="38.3794" width="0.2032" layer="1"/>
-<wire x1="44.958" y1="35.0774" x2="44.958" y2="34.9654" width="0.2032" layer="1"/>
-<wire x1="44.958" y1="39.2684" x2="44.997" y2="39.2684" width="0.2032" layer="1"/>
-<wire x1="44.069" y1="38.5064" x2="44.1325" y2="38.4429" width="0.2032" layer="1"/>
-<contactref element="USB1" pad="D+"/>
-<wire x1="44.069" y1="38.5064" x2="40.656" y2="38.5064" width="0.2032" layer="1"/>
-<wire x1="40.656" y1="38.5064" x2="40.513" y2="38.6494" width="0.2032" layer="1"/>
+<contactref element="JP1" pad="3"/>
+<wire x1="43.3644" y1="48.498" x2="44.6532" y2="48.498" width="0.1524" layer="1"/>
+<wire x1="44.6532" y1="48.498" x2="44.6532" y2="54.102" width="0.1524" layer="1"/>
+<wire x1="44.6532" y1="54.102" x2="45.72" y2="54.102" width="0.1524" layer="1"/>
+<wire x1="45.72" y1="54.102" x2="45.8724" y2="54.014" width="0.1524" layer="1"/>
+<wire x1="43.3644" y1="48.498" x2="42.0624" y2="48.498" width="0.1524" layer="1"/>
+<wire x1="42.0624" y1="48.498" x2="42.0624" y2="45.5676" width="0.1524" layer="1"/>
+<wire x1="42.0624" y1="45.5676" x2="44.6532" y2="45.5676" width="0.1524" layer="1"/>
+<wire x1="44.6532" y1="45.5676" x2="44.6532" y2="46.1772" width="0.1524" layer="1"/>
+<wire x1="44.6532" y1="46.1772" x2="45.6542" y2="46.1772" width="0.1524" layer="1"/>
+<wire x1="45.6542" y1="46.1772" x2="45.6796" y2="46.482" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$1">
 <contactref element="R1" pad="1"/>
 <contactref element="C4" pad="1"/>
-<wire x1="45.085" y1="36.6014" x2="46.609" y2="35.0774" width="0.2032" layer="1"/>
-<wire x1="45.085" y1="37.1094" x2="45.085" y2="36.6014" width="0.2032" layer="1"/>
-<wire x1="46.609" y1="35.0774" x2="46.609" y2="34.9654" width="0.2032" layer="1"/>
-<wire x1="45.847" y1="37.8714" x2="45.085" y2="37.1094" width="0.2032" layer="1"/>
-<wire x1="45.847" y1="39.9034" x2="45.847" y2="37.8714" width="0.2032" layer="1"/>
-<wire x1="45.212" y1="40.5384" x2="45.847" y2="39.9034" width="0.2032" layer="1"/>
-<wire x1="45.085" y1="37.1094" x2="44.997" y2="37.1094" width="0.2032" layer="1"/>
-<contactref element="USB1" pad="D-"/>
-<wire x1="45.212" y1="40.5384" x2="40.624" y2="40.5384" width="0.1524" layer="1"/>
-<wire x1="40.624" y1="40.5384" x2="40.513" y2="40.6494" width="0.1524" layer="1"/>
+<contactref element="JP1" pad="2"/>
+<wire x1="43.3644" y1="46.498" x2="44.958" y2="46.498" width="0.1524" layer="1"/>
+<wire x1="44.958" y1="46.498" x2="44.958" y2="47.7012" width="0.1524" layer="1"/>
+<wire x1="44.958" y1="47.7012" x2="44.958" y2="51.5112" width="0.1524" layer="1"/>
+<wire x1="44.958" y1="51.5112" x2="45.72" y2="51.5112" width="0.1524" layer="1"/>
+<wire x1="45.72" y1="51.5112" x2="45.8724" y2="51.4468" width="0.1524" layer="1"/>
+<wire x1="45.6796" y1="47.7012" x2="44.958" y2="47.7012" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$4">
 <contactref element="R1" pad="2"/>
 <contactref element="U1" pad="9"/>
-<wire x1="48.525" y1="30.3744" x2="48.525" y2="32.2724" width="0.2032" layer="1"/>
-<wire x1="48.525" y1="32.2724" x2="47.625" y2="33.1724" width="0.2032" layer="1"/>
-<wire x1="47.625" y1="33.1724" x2="47.625" y2="36.1814" width="0.2032" layer="1"/>
-<wire x1="47.625" y1="36.1814" x2="46.697" y2="37.1094" width="0.2032" layer="1"/>
+<wire x1="45.8724" y1="49.7468" x2="47.128" y2="49.7468" width="0.1524" layer="1"/>
+<wire x1="47.128" y1="49.7468" x2="47.128" y2="49.8054" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$5">
 <contactref element="R2" pad="2"/>
 <contactref element="U1" pad="8"/>
-<wire x1="48.514" y1="37.4904" x2="46.736" y2="39.2684" width="0.2032" layer="1"/>
-<wire x1="48.514" y1="36.4744" x2="48.514" y2="37.4904" width="0.2032" layer="1"/>
-<wire x1="46.736" y1="39.2684" x2="46.697" y2="39.2684" width="0.2032" layer="1"/>
-<wire x1="48.514" y1="36.4744" x2="48.525" y2="36.2244" width="0.2032" layer="1"/>
+<wire x1="45.8724" y1="55.714" x2="47.128" y2="55.714" width="0.1524" layer="1"/>
+<wire x1="47.128" y1="55.714" x2="47.128" y2="55.6554" width="0.1524" layer="1"/>
 </signal>
 <signal name="V+">
 <contactref element="R6" pad="2"/>
-<contactref element="J3" pad="2"/>
-<wire x1="69.977" y1="41.3394" x2="70.4478" y2="40.8686" width="0.1524" layer="1"/>
-<wire x1="70.4478" y1="40.8686" x2="73.6854" y2="40.8686" width="0.1524" layer="1"/>
-<wire x1="73.6854" y1="40.8686" x2="74.93" y2="39.624" width="0.1524" layer="1"/>
+<contactref element="JP3" pad="6"/>
+<wire x1="65.405" y1="50.7746" x2="64.4652" y2="49.8348" width="0.1524" layer="1"/>
+<wire x1="64.4652" y1="49.8348" x2="64.4652" y2="48.7036" width="0.1524" layer="1"/>
+<wire x1="64.4652" y1="48.7036" x2="64.5278" y2="48.641" width="0.1524" layer="1"/>
+<wire x1="65.405" y1="50.7746" x2="69.6214" y2="50.7746" width="0.1524" layer="1"/>
+<wire x1="69.6214" y1="50.7746" x2="69.6214" y2="50.673" width="0.1524" layer="1"/>
 </signal>
 <signal name="+3V3">
-<contactref element="R9" pad="2"/>
 <contactref element="R5" pad="2"/>
 <contactref element="R10" pad="2"/>
 <contactref element="R12" pad="2"/>
 <contactref element="R3" pad="2"/>
-<contactref element="J3" pad="1"/>
-<wire x1="72.81" y1="32.0294" x2="72.81" y2="29.9212" width="0.3048" layer="1"/>
-<wire x1="72.81" y1="29.9212" x2="72.81" y2="27.813" width="0.3048" layer="1"/>
-<wire x1="67.818" y1="41.3394" x2="67.818" y2="39.8018" width="0.1524" layer="1"/>
-<wire x1="67.818" y1="39.8018" x2="72.2884" y2="39.8018" width="0.1524" layer="1"/>
-<wire x1="72.2884" y1="39.8018" x2="74.93" y2="37.1602" width="0.1524" layer="1"/>
-<wire x1="74.93" y1="37.1602" x2="74.93" y2="37.084" width="0.1524" layer="1"/>
-<wire x1="74.5118" y1="45.847" x2="75.477" y2="46.8122" width="0.1524" layer="1"/>
-<wire x1="75.477" y1="46.8122" x2="77.0128" y2="46.8122" width="0.1524" layer="1"/>
-<wire x1="77.0128" y1="46.8122" x2="77.1652" y2="46.6598" width="0.1524" layer="1"/>
-<wire x1="77.1652" y1="46.6598" x2="77.1652" y2="44.196" width="0.1524" layer="1"/>
-<wire x1="77.1652" y1="44.196" x2="76.6318" y2="43.6626" width="0.1524" layer="1"/>
-<wire x1="76.6318" y1="43.6626" x2="76.6318" y2="43.1546" width="0.1524" layer="1"/>
-<wire x1="76.6318" y1="43.1546" x2="76.073" y2="42.5958" width="0.1524" layer="1"/>
-<wire x1="76.073" y1="42.5958" x2="76.073" y2="38.227" width="0.1524" layer="1"/>
-<wire x1="76.073" y1="38.227" x2="74.93" y2="37.084" width="0.1524" layer="1"/>
-<wire x1="72.81" y1="32.0294" x2="72.8218" y2="32.0294" width="0.3048" layer="1"/>
-<wire x1="72.8218" y1="32.0294" x2="72.8218" y2="35.3314" width="0.3048" layer="1"/>
-<via x="72.8218" y="35.3314" extent="1-16" drill="0.5"/>
-<wire x1="72.8218" y1="35.3314" x2="73.1774" y2="35.3314" width="0.3048" layer="16"/>
-<wire x1="73.1774" y1="35.3314" x2="74.93" y2="37.084" width="0.3048" layer="16"/>
+<contactref element="JP3" pad="1"/>
+<via x="68.7324" y="40.6908" extent="1-16" drill="0.5"/>
+<wire x1="60.5028" y1="39.6884" x2="62.3316" y2="39.6884" width="0.1524" layer="1"/>
+<wire x1="62.3316" y1="39.6884" x2="64.1604" y2="39.6884" width="0.1524" layer="1"/>
+<wire x1="64.1604" y1="39.6884" x2="63.8556" y2="39.624" width="0.1524" layer="1"/>
+<wire x1="63.8556" y1="39.624" x2="67.6656" y2="39.624" width="0.1524" layer="1"/>
+<wire x1="67.6656" y1="39.624" x2="68.7324" y2="40.6908" width="0.1524" layer="1"/>
+<wire x1="68.7324" y1="40.6908" x2="68.7324" y2="42.7736" width="0.1524" layer="16"/>
+<wire x1="64.9596" y1="44.8818" x2="66.5226" y2="44.8818" width="0.3048" layer="1"/>
+<wire x1="66.5226" y1="44.8818" x2="67.0814" y2="44.323" width="0.3048" layer="1"/>
+<wire x1="68.7324" y1="42.7736" x2="67.0814" y2="44.323" width="0.1524" layer="16"/>
 </signal>
 <signal name="VCCIO">
 <contactref element="C6" pad="1"/>
@@ -1950,221 +1922,175 @@ design rules under a new name.</description>
 <contactref element="C8" pad="1"/>
 <contactref element="U1" pad="3"/>
 <contactref element="R4" pad="2"/>
-<contactref element="J2" pad="5"/>
-<wire x1="48.852" y1="47.2034" x2="49.152" y2="46.9034" width="0.6096" layer="1"/>
-<wire x1="49.152" y1="46.9034" x2="50.546" y2="46.9034" width="0.6096" layer="1"/>
-<wire x1="50.546" y1="46.9034" x2="51.039" y2="47.3964" width="0.3048" layer="1"/>
-<wire x1="51.039" y1="47.3964" x2="52.563" y2="47.3964" width="0.3048" layer="1"/>
-<wire x1="52.563" y1="47.3964" x2="52.642" y2="47.3174" width="0.3048" layer="1"/>
-<wire x1="52.642" y1="47.3174" x2="52.642" y2="45.6184" width="0.3048" layer="1"/>
-<wire x1="50.546" y1="40.7534" x2="49.657" y2="40.7534" width="0.2032" layer="1"/>
-<wire x1="49.657" y1="40.7534" x2="49.657" y2="37.6174" width="0.2032" layer="1"/>
-<wire x1="49.657" y1="37.6174" x2="51.775" y2="37.6174" width="0.2032" layer="1"/>
-<wire x1="51.775" y1="37.6174" x2="51.775" y2="36.2244" width="0.2032" layer="1"/>
-<wire x1="52.578" y1="50.9524" x2="52.578" y2="47.3964" width="0.254" layer="1"/>
-<wire x1="52.578" y1="47.3964" x2="52.563" y2="47.3964" width="0.254" layer="1"/>
-<wire x1="52.578" y1="50.9524" x2="52.578" y2="51.3334" width="0.2032" layer="1"/>
-<wire x1="55.9054" y1="54.6608" x2="72.3138" y2="54.6608" width="0.2032" layer="1"/>
-<contactref element="R11" pad="2"/>
-<wire x1="48.852" y1="47.2034" x2="48.852" y2="47.668" width="0.3048" layer="1"/>
-<wire x1="48.852" y1="47.668" x2="45.466" y2="51.054" width="0.3048" layer="1"/>
-<wire x1="45.466" y1="51.054" x2="43.307" y2="51.054" width="0.3048" layer="1"/>
-<wire x1="43.307" y1="51.054" x2="42.799" y2="51.562" width="0.3048" layer="1"/>
-<wire x1="42.799" y1="51.562" x2="42.799" y2="52.539" width="0.3048" layer="1"/>
-<wire x1="42.799" y1="52.539" x2="43.141" y2="52.578" width="0.3048" layer="1"/>
-<wire x1="52.578" y1="51.3334" x2="55.9054" y2="54.6608" width="0.2032" layer="1"/>
-<wire x1="72.3138" y1="54.6608" x2="72.39" y2="54.61" width="0.2032" layer="1"/>
-<wire x1="72.39" y1="54.61" x2="72.39" y2="52.1716" width="0.2032" layer="1"/>
-<wire x1="50.546" y1="40.7534" x2="52.642" y2="40.7534" width="0.2032" layer="1"/>
-<wire x1="52.642" y1="40.7534" x2="52.642" y2="45.6184" width="0.2032" layer="1"/>
+<contactref element="JP2" pad="4"/>
+<wire x1="50.292" y1="41.0614" x2="50.292" y2="41.3614" width="0.3048" layer="1"/>
+<wire x1="50.292" y1="41.3614" x2="48.725" y2="41.3614" width="0.3048" layer="1"/>
+<wire x1="48.725" y1="41.3614" x2="48.7816" y2="41.3614" width="0.3048" layer="1"/>
+<wire x1="48.7816" y1="41.3614" x2="48.7816" y2="42.926" width="0.3048" layer="1"/>
+<wire x1="52.8828" y1="46.2046" x2="52.896" y2="46.2046" width="0.3048" layer="1"/>
+<wire x1="52.896" y1="46.2046" x2="52.896" y2="47.879" width="0.3048" layer="1"/>
+<wire x1="52.896" y1="47.879" x2="52.7916" y2="47.879" width="0.3048" layer="1"/>
+<wire x1="52.7916" y1="47.879" x2="52.7916" y2="50.7492" width="0.3048" layer="1"/>
+<wire x1="52.7916" y1="50.7492" x2="50.378" y2="50.7492" width="0.3048" layer="1"/>
+<wire x1="50.378" y1="55.6554" x2="50.378" y2="52.4256" width="0.3048" layer="1"/>
+<wire x1="50.378" y1="52.4256" x2="50.378" y2="50.7492" width="0.3048" layer="1"/>
+<wire x1="54.6862" y1="56.388" x2="52.7304" y2="56.388" width="0.1524" layer="1"/>
+<wire x1="52.7304" y1="56.388" x2="52.7304" y2="52.4256" width="0.1524" layer="1"/>
+<wire x1="52.7304" y1="52.4256" x2="52.8828" y2="52.4256" width="0.1524" layer="1"/>
+<via x="52.8828" y="52.4256" extent="1-16" drill="0.5"/>
+<wire x1="52.8828" y1="52.4256" x2="51.054" y2="52.4256" width="0.1524" layer="16"/>
+<via x="51.054" y="52.4256" extent="1-16" drill="0.5"/>
+<wire x1="51.054" y1="52.4256" x2="50.378" y2="52.4256" width="0.1524" layer="1"/>
+<wire x1="54.6862" y1="56.388" x2="56.388" y2="54.6862" width="0.1524" layer="1"/>
+<wire x1="56.388" y1="54.6862" x2="56.388" y2="54.5338" width="0.1524" layer="1"/>
+<wire x1="48.7816" y1="42.926" x2="48.7816" y2="46.2046" width="0.3048" layer="1"/>
+<wire x1="48.7816" y1="46.2046" x2="52.896" y2="46.2046" width="0.3048" layer="1"/>
 </signal>
 <signal name="N$21">
 <contactref element="R4" pad="1"/>
 <contactref element="U3" pad="1"/>
-<contactref element="J2" pad="6"/>
-<contactref element="U1" pad="16"/>
-<wire x1="50.546" y1="39.0534" x2="50.585" y2="39.0144" width="0.2032" layer="1"/>
-<wire x1="50.585" y1="39.0144" x2="52.642" y2="39.0144" width="0.2032" layer="1"/>
-<wire x1="52.642" y1="39.0144" x2="52.642" y2="40.3098" width="0.1524" layer="1"/>
-<wire x1="52.642" y1="40.3098" x2="53.0352" y2="40.3098" width="0.1524" layer="1"/>
-<wire x1="53.0352" y1="40.3098" x2="53.0352" y2="42.9006" width="0.1524" layer="1"/>
-<wire x1="53.0352" y1="42.9006" x2="63.5508" y2="42.9006" width="0.1524" layer="1"/>
-<wire x1="63.5508" y1="42.9006" x2="64.008" y2="42.4434" width="0.1524" layer="1"/>
-<via x="64.008" y="42.4434" extent="1-16" drill="0.5"/>
-<wire x1="64.008" y1="42.4434" x2="64.008" y2="45.4914" width="0.1524" layer="16"/>
-<via x="64.008" y="45.4914" extent="1-16" drill="0.5"/>
-<wire x1="64.008" y1="45.4914" x2="64.008" y2="48.2092" width="0.1524" layer="1"/>
-<wire x1="52.642" y1="39.0144" x2="52.642" y2="37.7312" width="0.1524" layer="1"/>
-<via x="54.2036" y="35.7632" extent="1-16" drill="0.5"/>
-<wire x1="54.2036" y1="35.7632" x2="54.2036" y2="33.9852" width="0.1524" layer="16"/>
-<via x="54.2036" y="33.9852" extent="1-16" drill="0.5"/>
-<wire x1="54.2036" y1="33.9852" x2="54.2036" y2="31.503" width="0.1524" layer="1"/>
-<wire x1="54.2036" y1="31.503" x2="53.075" y2="30.3744" width="0.1524" layer="1"/>
-<wire x1="52.642" y1="37.7312" x2="52.8828" y2="37.4904" width="0.1524" layer="1"/>
-<wire x1="52.8828" y1="37.4904" x2="53.8988" y2="37.4904" width="0.1524" layer="1"/>
-<wire x1="53.8988" y1="37.4904" x2="54.2036" y2="37.1856" width="0.1524" layer="1"/>
-<wire x1="54.2036" y1="37.1856" x2="54.2036" y2="35.7632" width="0.1524" layer="1"/>
-<wire x1="64.008" y1="48.2092" x2="65.405" y2="49.6062" width="0.1524" layer="1"/>
-<wire x1="65.405" y1="49.6062" x2="74.168" y2="49.6062" width="0.1524" layer="1"/>
-<wire x1="74.168" y1="49.6062" x2="74.9046" y2="50.3428" width="0.1524" layer="1"/>
-<wire x1="74.9046" y1="50.3428" x2="74.9046" y2="52.1462" width="0.1524" layer="1"/>
-<wire x1="74.9046" y1="52.1462" x2="74.93" y2="52.1716" width="0.1524" layer="1"/>
+<contactref element="JP2" pad="5"/>
+<wire x1="50.4816" y1="42.926" x2="51.054" y2="42.926" width="0.1524" layer="1"/>
+<wire x1="51.054" y1="42.926" x2="51.054" y2="39.0144" width="0.1524" layer="1"/>
+<wire x1="51.054" y1="39.0144" x2="52.896" y2="39.0144" width="0.1524" layer="1"/>
+<wire x1="52.896" y1="39.0144" x2="52.896" y2="39.3426" width="0.1524" layer="1"/>
+<wire x1="54.4068" y1="49.8348" x2="52.578" y2="48.006" width="0.1524" layer="16"/>
+<wire x1="52.578" y1="48.006" x2="52.578" y2="44.5008" width="0.1524" layer="16"/>
+<via x="52.578" y="44.5008" extent="1-16" drill="0.5"/>
+<wire x1="52.578" y1="44.5008" x2="52.578" y2="42.926" width="0.1524" layer="1"/>
+<wire x1="52.578" y1="42.926" x2="50.4816" y2="42.926" width="0.1524" layer="1"/>
+<wire x1="54.4068" y1="54.5338" x2="54.4068" y2="49.8348" width="0.1524" layer="1"/>
+<via x="54.4068" y="49.8348" extent="1-16" drill="0.5"/>
+<wire x1="54.4068" y1="54.5338" x2="53.848" y2="54.5338" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$17">
 <contactref element="R6" pad="1"/>
 <contactref element="R7" pad="2"/>
 <contactref element="C7" pad="1"/>
 <contactref element="U3" pad="15"/>
-<wire x1="69.977" y1="44.3874" x2="69.977" y2="43.0394" width="0.2032" layer="1"/>
-<wire x1="69.977" y1="44.3874" x2="69.684" y2="44.3874" width="0.2032" layer="1"/>
-<wire x1="69.684" y1="44.3874" x2="68.834" y2="45.2374" width="0.2032" layer="1"/>
-<wire x1="68.834" y1="45.2374" x2="66.04" y2="45.2374" width="0.2032" layer="1"/>
-<wire x1="56.642" y1="48.7784" x2="56.007" y2="48.1434" width="0.2032" layer="1"/>
-<wire x1="56.007" y1="48.1434" x2="56.007" y2="46.8884" width="0.2032" layer="1"/>
-<wire x1="56.007" y1="46.8884" x2="55.817" y2="46.6984" width="0.2032" layer="1"/>
-<wire x1="55.817" y1="46.6984" x2="55.817" y2="45.6184" width="0.2032" layer="1"/>
-<wire x1="66.04" y1="45.2374" x2="66.04" y2="44.7294" width="0.2032" layer="1"/>
-<wire x1="66.04" y1="44.7294" x2="60.5028" y2="44.7294" width="0.2032" layer="1"/>
-<wire x1="60.5028" y1="44.7294" x2="60.5028" y2="48.7784" width="0.2032" layer="1"/>
-<wire x1="60.5028" y1="48.7784" x2="56.642" y2="48.7784" width="0.2032" layer="1"/>
-</signal>
-<signal name="N$20">
-<contactref element="R8" pad="2"/>
-<contactref element="R9" pad="1"/>
-<contactref element="C9" pad="1"/>
-<contactref element="U3" pad="16"/>
-<wire x1="67.818" y1="44.3874" x2="67.818" y2="43.0394" width="0.2032" layer="1"/>
-<wire x1="67.818" y1="44.3874" x2="66.421" y2="44.3874" width="0.2032" layer="1"/>
-<via x="55.245" y="47.2694" extent="1-16" drill="0.5"/>
-<wire x1="55.182" y1="45.6184" x2="55.245" y2="45.6814" width="0.2032" layer="1"/>
-<wire x1="55.245" y1="45.6814" x2="55.245" y2="47.2694" width="0.2032" layer="1"/>
-<wire x1="55.245" y1="47.2694" x2="55.245" y2="48.7784" width="0.2032" layer="1"/>
-<via x="56.769" y="47.2694" extent="1-16" drill="0.5"/>
-<wire x1="56.769" y1="47.2694" x2="55.245" y2="47.2694" width="0.2032" layer="16"/>
-<wire x1="66.421" y1="44.3874" x2="66.421" y2="44.2214" width="0.2032" layer="1"/>
-<wire x1="66.421" y1="44.2214" x2="60.0456" y2="44.2214" width="0.2032" layer="1"/>
-<wire x1="60.0456" y1="44.2214" x2="60.0456" y2="47.2694" width="0.2032" layer="1"/>
-<wire x1="60.0456" y1="47.2694" x2="56.769" y2="47.2694" width="0.2032" layer="1"/>
+<wire x1="56.071" y1="46.2046" x2="56.071" y2="47.689" width="0.1524" layer="1"/>
+<wire x1="56.071" y1="47.689" x2="56.5404" y2="48.1584" width="0.1524" layer="1"/>
+<via x="56.5404" y="48.1584" extent="1-16" drill="0.5"/>
+<wire x1="56.5404" y1="48.1584" x2="56.5404" y2="49.6824" width="0.1524" layer="16"/>
+<via x="56.5404" y="49.6824" extent="1-16" drill="0.5"/>
+<wire x1="61.5052" y1="48.641" x2="62.8278" y2="48.641" width="0.1524" layer="1"/>
+<wire x1="61.5052" y1="48.641" x2="61.5592" y2="48.695" width="0.1524" layer="1"/>
+<wire x1="61.5592" y1="48.695" x2="61.5592" y2="50.0888" width="0.1524" layer="1"/>
+<wire x1="56.5404" y1="49.6824" x2="58.3692" y2="49.6824" width="0.1524" layer="1"/>
+<wire x1="58.3692" y1="49.6824" x2="59.5884" y2="50.9016" width="0.1524" layer="1"/>
+<wire x1="59.5884" y1="50.9016" x2="61.5696" y2="50.9016" width="0.1524" layer="1"/>
+<wire x1="61.5696" y1="50.9016" x2="61.5696" y2="50.0992" width="0.1524" layer="1"/>
+<wire x1="61.5696" y1="50.0992" x2="61.5592" y2="50.0888" width="0.1524" layer="1"/>
 </signal>
 <signal name="PICTX1">
 <contactref element="U3" pad="11"/>
 <contactref element="U1" pad="4"/>
-<wire x1="51.125" y1="36.2244" x2="51.125" y2="35.3366" width="0.1524" layer="1"/>
-<wire x1="51.125" y1="35.3366" x2="51.7398" y2="34.7218" width="0.1524" layer="1"/>
-<wire x1="51.7398" y1="34.7218" x2="55.5752" y2="34.7218" width="0.1524" layer="1"/>
-<wire x1="55.5752" y1="34.7218" x2="56.4896" y2="35.6362" width="0.1524" layer="1"/>
-<wire x1="56.4896" y1="35.6362" x2="56.4896" y2="37.1856" width="0.1524" layer="1"/>
-<wire x1="56.4896" y1="37.1856" x2="57.023" y2="37.719" width="0.1524" layer="1"/>
-<wire x1="57.023" y1="37.719" x2="59.2328" y2="37.719" width="0.1524" layer="1"/>
-<wire x1="59.2328" y1="37.719" x2="59.2328" y2="41.3004" width="0.1524" layer="1"/>
-<via x="59.2328" y="41.3004" extent="1-16" drill="0.5"/>
-<wire x1="59.2328" y1="41.3004" x2="59.2328" y2="44.7548" width="0.1524" layer="16"/>
-<via x="59.2328" y="44.7548" extent="1-16" drill="0.5"/>
-<wire x1="59.2328" y1="44.7548" x2="59.2328" y2="45.6184" width="0.1524" layer="1"/>
-<wire x1="59.2328" y1="45.6184" x2="58.357" y2="45.6184" width="0.1524" layer="1"/>
+<wire x1="49.728" y1="55.6554" x2="49.728" y2="56.5404" width="0.1524" layer="1"/>
+<wire x1="49.728" y1="56.5404" x2="52.1208" y2="56.5404" width="0.1524" layer="1"/>
+<wire x1="52.1208" y1="56.5404" x2="52.1208" y2="51.5112" width="0.1524" layer="1"/>
+<wire x1="52.1208" y1="51.5112" x2="53.4924" y2="51.5112" width="0.1524" layer="1"/>
+<wire x1="53.4924" y1="51.5112" x2="53.4924" y2="48.9204" width="0.1524" layer="1"/>
+<wire x1="53.4924" y1="48.9204" x2="57.3024" y2="48.9204" width="0.1524" layer="1"/>
+<wire x1="57.3024" y1="48.9204" x2="57.3024" y2="48.1584" width="0.1524" layer="1"/>
+<wire x1="58.611" y1="48.1584" x2="58.611" y2="46.2046" width="0.1524" layer="1"/>
+<wire x1="57.3024" y1="48.1584" x2="58.611" y2="48.1584" width="0.1524" layer="1"/>
 </signal>
 <signal name="PICRX1">
 <contactref element="U3" pad="6"/>
 <contactref element="U1" pad="1"/>
-<wire x1="55.8292" y1="39.0022" x2="55.817" y2="39.0144" width="0.1524" layer="1"/>
-<wire x1="53.075" y1="36.2244" x2="53.075" y2="35.3424" width="0.1524" layer="1"/>
-<wire x1="53.075" y1="35.3424" x2="53.3908" y2="35.0266" width="0.1524" layer="1"/>
-<wire x1="53.3908" y1="35.0266" x2="55.2704" y2="35.0266" width="0.1524" layer="1"/>
-<wire x1="55.2704" y1="35.0266" x2="55.817" y2="35.5732" width="0.1524" layer="1"/>
-<wire x1="55.817" y1="35.5732" x2="55.817" y2="39.0144" width="0.1524" layer="1"/>
+<wire x1="51.678" y1="55.6554" x2="51.816" y2="55.365" width="0.1524" layer="1"/>
+<wire x1="51.816" y1="55.365" x2="51.816" y2="51.2064" width="0.1524" layer="1"/>
+<wire x1="51.816" y1="51.2064" x2="53.1876" y2="51.2064" width="0.1524" layer="1"/>
+<wire x1="53.1876" y1="51.2064" x2="53.1876" y2="48.6156" width="0.1524" layer="1"/>
+<wire x1="53.1876" y1="48.6156" x2="55.3212" y2="48.6156" width="0.1524" layer="1"/>
+<wire x1="55.3212" y1="48.6156" x2="55.3212" y2="48.1584" width="0.1524" layer="1"/>
+<via x="55.3212" y="48.1584" extent="1-16" drill="0.5"/>
+<wire x1="55.3212" y1="48.1584" x2="55.3212" y2="44.3484" width="0.1524" layer="16"/>
+<via x="55.3212" y="44.3484" extent="1-16" drill="0.5"/>
+<wire x1="56.071" y1="43.751" x2="56.071" y2="39.3426" width="0.1524" layer="1"/>
+<wire x1="56.071" y1="43.751" x2="55.3212" y2="44.3484" width="0.1524" layer="1"/>
 </signal>
 <signal name="CLOCKRX">
 <contactref element="U3" pad="4"/>
 </signal>
 <signal name="N$8">
-<contactref element="J2" pad="2"/>
 <contactref element="U3" pad="10"/>
-<wire x1="58.357" y1="39.0144" x2="58.357" y2="42.2148" width="0.1524" layer="1"/>
-<via x="61.6204" y="41.7576" extent="1-16" drill="0.5"/>
-<wire x1="61.6204" y1="41.7576" x2="61.6204" y2="45.5168" width="0.1524" layer="16"/>
-<via x="61.6204" y="45.5168" extent="1-16" drill="0.5"/>
-<wire x1="58.357" y1="42.2148" x2="61.1632" y2="42.2148" width="0.1524" layer="1"/>
-<wire x1="61.1632" y1="42.2148" x2="61.6204" y2="41.7576" width="0.1524" layer="1"/>
-<wire x1="61.6204" y1="45.5168" x2="61.6204" y2="48.0314" width="0.1524" layer="1"/>
-<wire x1="61.6204" y1="48.0314" x2="63.4238" y2="49.8348" width="0.1524" layer="1"/>
-<wire x1="63.4238" y1="49.8348" x2="64.3382" y2="49.8348" width="0.1524" layer="1"/>
-<wire x1="64.3382" y1="49.8348" x2="64.6684" y2="50.165" width="0.1524" layer="1"/>
-<wire x1="64.6684" y1="50.165" x2="64.6684" y2="52.07" width="0.1524" layer="1"/>
-<wire x1="64.6684" y1="52.07" x2="64.77" y2="52.1716" width="0.1524" layer="1"/>
+<contactref element="JP2" pad="1"/>
+<wire x1="58.611" y1="38.5572" x2="72.5424" y2="38.5572" width="0.1524" layer="1"/>
+<wire x1="72.5424" y1="38.5572" x2="72.5424" y2="54.5338" width="0.1524" layer="1"/>
+<wire x1="72.5424" y1="54.5338" x2="64.008" y2="54.5338" width="0.1524" layer="1"/>
+<wire x1="58.611" y1="38.5572" x2="58.611" y2="39.3426" width="0.1524" layer="1"/>
 </signal>
 <signal name="N$9">
-<contactref element="J2" pad="3"/>
 <contactref element="U3" pad="9"/>
-<wire x1="57.722" y1="39.0144" x2="57.722" y2="42.5704" width="0.1524" layer="1"/>
-<via x="62.8142" y="42.1386" extent="1-16" drill="0.5"/>
-<wire x1="62.8142" y1="42.1386" x2="62.8142" y2="45.4914" width="0.1524" layer="16"/>
-<via x="62.8142" y="45.4914" extent="1-16" drill="0.5"/>
-<wire x1="57.722" y1="42.5704" x2="62.3824" y2="42.5704" width="0.1524" layer="1"/>
-<wire x1="62.3824" y1="42.5704" x2="62.8142" y2="42.1386" width="0.1524" layer="1"/>
-<wire x1="62.8142" y1="45.4914" x2="62.8142" y2="48.5648" width="0.1524" layer="1"/>
-<wire x1="62.8142" y1="48.5648" x2="63.5254" y2="49.276" width="0.1524" layer="1"/>
-<wire x1="63.5254" y1="49.276" x2="64.389" y2="49.276" width="0.1524" layer="1"/>
-<wire x1="64.389" y1="49.276" x2="65.2272" y2="50.1142" width="0.1524" layer="1"/>
-<wire x1="65.2272" y1="50.1142" x2="65.2526" y2="50.1142" width="0.1524" layer="1"/>
-<wire x1="65.2526" y1="50.1142" x2="67.31" y2="52.1716" width="0.1524" layer="1"/>
-</signal>
-<signal name="N$12">
-<contactref element="LED1" pad="A"/>
-<contactref element="R11" pad="1"/>
-<wire x1="41.441" y1="52.578" x2="37.719" y2="52.578" width="0.3048" layer="1"/>
-</signal>
-<signal name="N$13">
-<contactref element="LED2" pad="A"/>
-<contactref element="R12" pad="1"/>
-<wire x1="74.51" y1="27.813" x2="78.105" y2="27.813" width="0.254" layer="1"/>
+<contactref element="JP2" pad="2"/>
+<wire x1="57.976" y1="39.3426" x2="58.0644" y2="39.431" width="0.1524" layer="1"/>
+<wire x1="58.0644" y1="39.431" x2="58.0644" y2="40.5384" width="0.1524" layer="1"/>
+<wire x1="58.0644" y1="40.5384" x2="59.2836" y2="40.5384" width="0.1524" layer="1"/>
+<wire x1="59.2836" y1="40.5384" x2="59.2836" y2="38.862" width="0.1524" layer="1"/>
+<wire x1="59.2836" y1="38.862" x2="72.2376" y2="38.862" width="0.1524" layer="1"/>
+<wire x1="72.2376" y1="38.862" x2="72.2376" y2="52.7304" width="0.1524" layer="1"/>
+<wire x1="72.2376" y1="52.7304" x2="61.4172" y2="52.7304" width="0.1524" layer="1"/>
+<wire x1="61.4172" y1="52.7304" x2="61.4172" y2="54.5338" width="0.1524" layer="1"/>
+<wire x1="61.4172" y1="54.5338" x2="61.468" y2="54.5338" width="0.1524" layer="1"/>
 </signal>
 <signal name="CLOCK">
 <contactref element="R10" pad="1"/>
 <contactref element="U3" pad="12"/>
-<contactref element="J3" pad="3"/>
-<wire x1="57.722" y1="45.6184" x2="57.722" y2="43.8404" width="0.1524" layer="1"/>
-<wire x1="57.722" y1="43.8404" x2="66.0908" y2="43.8404" width="0.1524" layer="1"/>
-<wire x1="66.0908" y1="43.8404" x2="66.7004" y2="43.2308" width="0.1524" layer="1"/>
-<wire x1="66.7004" y1="43.2308" x2="66.7004" y2="42.1386" width="0.1524" layer="1"/>
-<wire x1="66.7004" y1="42.1386" x2="74.93" y2="42.1386" width="0.1524" layer="1"/>
-<wire x1="74.93" y1="42.164" x2="76.2118" y2="43.4458" width="0.1524" layer="1"/>
-<wire x1="76.2118" y1="43.4458" x2="76.2118" y2="45.847" width="0.1524" layer="1"/>
-<wire x1="74.93" y1="42.1386" x2="74.93" y2="42.164" width="0.1524" layer="1"/>
+<contactref element="JP3" pad="2"/>
+<wire x1="57.972" y1="46.2046" x2="57.972" y2="45.0504" width="0.1524" layer="1"/>
+<wire x1="57.972" y1="45.0504" x2="59.7408" y2="43.18" width="0.1524" layer="1"/>
+<wire x1="59.7408" y1="43.18" x2="70.2564" y2="43.18" width="0.1524" layer="1"/>
+<wire x1="70.2564" y1="43.18" x2="71.0184" y2="44.0436" width="0.1524" layer="1"/>
+<wire x1="71.0184" y1="44.0436" x2="71.0184" y2="45.5676" width="0.1524" layer="1"/>
+<wire x1="71.0184" y1="45.5676" x2="69.7484" y2="45.5676" width="0.1524" layer="1"/>
+<wire x1="69.7484" y1="45.5676" x2="69.6214" y2="45.593" width="0.1524" layer="1"/>
+<wire x1="64.1604" y1="41.3884" x2="69.1252" y2="41.3884" width="0.1524" layer="1"/>
+<wire x1="69.1252" y1="41.3884" x2="69.6468" y2="41.8084" width="0.1524" layer="1"/>
+<via x="69.6468" y="41.8084" extent="1-16" drill="0.5"/>
+<wire x1="69.6468" y1="41.8084" x2="69.6468" y2="45.6692" width="0.1524" layer="16"/>
+<wire x1="69.6468" y1="45.6692" x2="69.6214" y2="45.593" width="0.1524" layer="16"/>
 </signal>
 <signal name="DATA">
 <contactref element="R5" pad="1"/>
 <contactref element="U3" pad="13"/>
-<contactref element="J3" pad="4"/>
-<wire x1="74.51" y1="32.0294" x2="77.47" y2="34.9894" width="0.1524" layer="1"/>
-<wire x1="77.47" y1="34.9894" x2="77.47" y2="36.1696" width="0.1524" layer="1"/>
-<wire x1="77.47" y1="36.1696" x2="77.47" y2="37.084" width="0.1524" layer="1"/>
-<wire x1="57.087" y1="45.6184" x2="57.087" y2="43.5356" width="0.1524" layer="1"/>
-<wire x1="57.087" y1="43.5356" x2="64.6176" y2="43.5356" width="0.1524" layer="1"/>
-<wire x1="64.6176" y1="43.5356" x2="65.3796" y2="42.7736" width="0.1524" layer="1"/>
-<wire x1="65.3796" y1="42.7736" x2="65.3796" y2="39.4208" width="0.1524" layer="1"/>
-<wire x1="65.3796" y1="39.4208" x2="71.8566" y2="39.4208" width="0.1524" layer="1"/>
-<wire x1="71.8566" y1="39.4208" x2="72.8472" y2="38.4302" width="0.1524" layer="1"/>
-<wire x1="72.8472" y1="38.4302" x2="72.8472" y2="36.8808" width="0.1524" layer="1"/>
-<wire x1="72.8472" y1="36.8808" x2="73.7108" y2="36.0172" width="0.1524" layer="1"/>
-<wire x1="73.7108" y1="36.0172" x2="77.3176" y2="36.0172" width="0.1524" layer="1"/>
-<wire x1="77.3176" y1="36.0172" x2="77.47" y2="36.1696" width="0.1524" layer="1" curve="90"/>
+<contactref element="JP3" pad="3"/>
+<wire x1="57.341" y1="46.2046" x2="57.3024" y2="46.166" width="0.1524" layer="1"/>
+<wire x1="57.341" y1="46.2046" x2="57.341" y2="45.2242" width="0.1524" layer="1"/>
+<wire x1="57.341" y1="45.2242" x2="59.5884" y2="42.8752" width="0.1524" layer="1"/>
+<wire x1="59.5884" y1="42.8752" x2="62.3316" y2="42.8752" width="0.1524" layer="1"/>
+<wire x1="62.3316" y1="41.3884" x2="62.3316" y2="42.8752" width="0.1524" layer="1"/>
+<wire x1="62.3316" y1="42.8752" x2="70.4088" y2="42.8752" width="0.1524" layer="1"/>
+<wire x1="70.4088" y1="42.8752" x2="71.3232" y2="43.8912" width="0.1524" layer="1"/>
+<wire x1="71.3232" y1="43.8912" x2="71.3232" y2="46.7868" width="0.1524" layer="1"/>
+<wire x1="71.3232" y1="46.7868" x2="71.247" y2="46.863" width="0.1524" layer="1"/>
+<wire x1="71.247" y1="46.863" x2="67.0814" y2="46.863" width="0.1524" layer="1"/>
 </signal>
 <signal name="ALARM">
 <contactref element="R3" pad="1"/>
 <contactref element="U3" pad="18"/>
-<contactref element="J3" pad="5"/>
-<wire x1="74.51" y1="29.9212" x2="78.7146" y2="34.1258" width="0.1524" layer="1"/>
-<wire x1="78.7146" y1="34.1258" x2="78.7146" y2="38.3794" width="0.1524" layer="1"/>
-<wire x1="78.7146" y1="38.3794" x2="77.47" y2="39.624" width="0.1524" layer="1"/>
-<wire x1="53.912" y1="45.6184" x2="53.912" y2="43.2308" width="0.1524" layer="1"/>
-<wire x1="53.912" y1="43.2308" x2="64.389" y2="43.2308" width="0.1524" layer="1"/>
-<wire x1="64.389" y1="43.2308" x2="64.9224" y2="42.6974" width="0.1524" layer="1"/>
-<wire x1="64.9224" y1="42.6974" x2="64.9224" y2="39.0906" width="0.1524" layer="1"/>
-<wire x1="64.9224" y1="39.0906" x2="71.0438" y2="39.0906" width="0.1524" layer="1"/>
-<wire x1="71.0438" y1="39.0906" x2="71.0438" y2="26.4922" width="0.1524" layer="1"/>
-<wire x1="71.0438" y1="26.4922" x2="79.1718" y2="26.4922" width="0.1524" layer="1"/>
-<wire x1="79.1718" y1="26.4922" x2="79.1718" y2="33.6686" width="0.1524" layer="1"/>
-<wire x1="79.1718" y1="33.6686" x2="78.7146" y2="34.1258" width="0.1524" layer="1"/>
+<contactref element="JP3" pad="4"/>
+<wire x1="54.166" y1="46.2046" x2="54.166" y2="45.3512" width="0.1524" layer="1"/>
+<wire x1="54.166" y1="45.3512" x2="54.4068" y2="45.1104" width="0.1524" layer="1"/>
+<wire x1="54.4068" y1="45.1104" x2="56.9976" y2="45.1104" width="0.1524" layer="1"/>
+<wire x1="56.9976" y1="45.1104" x2="59.436" y2="42.5704" width="0.1524" layer="1"/>
+<wire x1="59.436" y1="42.5704" x2="60.5028" y2="42.5704" width="0.1524" layer="1"/>
+<wire x1="60.5028" y1="42.5704" x2="60.5028" y2="41.3884" width="0.1524" layer="1"/>
+<wire x1="60.5028" y1="41.3884" x2="60.5028" y2="40.5384" width="0.1524" layer="1"/>
+<wire x1="60.5028" y1="40.5384" x2="63.246" y2="40.5384" width="0.1524" layer="1"/>
+<wire x1="63.246" y1="40.5384" x2="63.246" y2="42.5704" width="0.1524" layer="1"/>
+<wire x1="63.246" y1="42.5704" x2="70.5612" y2="42.5704" width="0.1524" layer="1"/>
+<wire x1="70.5612" y1="42.5704" x2="71.628" y2="43.7388" width="0.1524" layer="1"/>
+<wire x1="71.628" y1="43.7388" x2="71.628" y2="47.3964" width="0.1524" layer="1"/>
+<wire x1="71.628" y1="47.3964" x2="70.866" y2="48.1584" width="0.1524" layer="1"/>
+<wire x1="70.866" y1="48.1584" x2="69.6468" y2="48.1584" width="0.1524" layer="1"/>
+<wire x1="69.6468" y1="48.1584" x2="69.6214" y2="48.133" width="0.1524" layer="1"/>
+</signal>
+<signal name="N$7">
+<contactref element="R12" pad="1"/>
+<contactref element="LED2" pad="A"/>
+<wire x1="63.2596" y1="44.8818" x2="63.2342" y2="44.8564" width="0.3048" layer="1"/>
+<wire x1="63.2342" y1="44.8564" x2="62.1418" y2="44.8564" width="0.3048" layer="1"/>
 </signal>
 </signals>
 </board>

--- a/pcb/programming_board/programming_board.sch
+++ b/pcb/programming_board/programming_board.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.4">
+<eagle version="6.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -269,26 +269,26 @@ CAD and Schematic files for the PIC24Fka101 series of microcontrollers.</descrip
 <wire x1="3.366" y1="2.286" x2="-3.365" y2="2.286" width="0.0508" layer="21"/>
 <wire x1="-3.365" y1="-2.286" x2="-3.365" y2="2.286" width="0.0508" layer="21"/>
 <circle x="-2.349" y="-1.397" radius="0.635" width="0.1524" layer="21"/>
-<smd name="1" x="-2.857" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="2" x="-2.222" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="3" x="-1.587" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="4" x="-0.952" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="5" x="-0.317" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="6" x="0.318" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="7" x="0.953" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="8" x="1.588" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="9" x="2.223" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="10" x="2.858" y="-3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="20" x="-2.857" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="19" x="-2.222" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="18" x="-1.587" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="17" x="-0.952" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="16" x="-0.317" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="15" x="0.318" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="14" x="0.953" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="13" x="1.588" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="12" x="2.223" y="3.302" dx="0.305" dy="1.245" layer="1"/>
-<smd name="11" x="2.858" y="3.302" dx="0.305" dy="1.245" layer="1"/>
+<smd name="1" x="-2.857" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="2" x="-2.222" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="3" x="-1.587" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="4" x="-0.952" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="5" x="-0.317" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="6" x="0.318" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="7" x="0.953" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="8" x="1.588" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="9" x="2.223" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="10" x="2.858" y="-3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="20" x="-2.857" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="19" x="-2.222" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="18" x="-1.587" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="17" x="-0.952" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="16" x="-0.317" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="15" x="0.318" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="14" x="0.953" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="13" x="1.588" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="12" x="2.219" y="3.431" dx="0.3" dy="1.5" layer="1"/>
+<smd name="11" x="2.858" y="3.431" dx="0.3" dy="1.5" layer="1"/>
 <text x="-4.064" y="-2.1204" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
 <text x="-2.7554" y="-0.0254" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
 <rectangle x1="2.7564" y1="2.5908" x2="2.9596" y2="3.429" layer="51"/>
@@ -333,35 +333,41 @@ reflow soldering</description>
 <rectangle x1="-1.1684" y1="-1.2954" x2="-0.7112" y2="-0.7112" layer="51"/>
 <rectangle x1="-0.5001" y1="-0.3" x2="0.5001" y2="0.3" layer="35"/>
 </package>
-<package name="2X3-MOLEX-90130">
-<pad name="1" x="-2.54" y="2.54" drill="1"/>
-<pad name="2" x="0" y="2.54" drill="1"/>
-<pad name="3" x="2.54" y="2.54" drill="1"/>
-<pad name="6" x="2.54" y="0" drill="1"/>
-<pad name="5" x="0" y="0" drill="1"/>
-<pad name="4" x="-2.54" y="0" drill="1"/>
-<text x="0.635" y="4.445" size="0.8128" layer="25">&gt;NAME</text>
-<wire x1="4.9784" y1="-3.2766" x2="4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="-3.2766" x2="-4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="5.8166" x2="4.9784" y2="5.8166" width="0.127" layer="21"/>
-<wire x1="-4.9784" y1="-3.2766" x2="4.9784" y2="-3.2766" width="0.127" layer="21"/>
-<wire x1="-1.27" y1="-3.175" x2="-1.27" y2="-4.445" width="0.127" layer="21"/>
-<wire x1="-1.27" y1="-4.445" x2="1.27" y2="-4.445" width="0.127" layer="21"/>
-<wire x1="1.27" y1="-4.445" x2="1.27" y2="-3.175" width="0.127" layer="21"/>
-<wire x1="1.27" y1="-3.175" x2="-1.27" y2="-3.175" width="0.127" layer="21"/>
+<package name="USB-MALE-EDGE">
+<description>Male USB-A port mounted on the edge of PCB. Molex part number 48037-2000</description>
+<wire x1="-5.7" y1="-1" x2="5.7" y2="-1" width="0.254" layer="21"/>
+<pad name="P$1" x="-5.7" y="1.75" drill="2.4"/>
+<pad name="P$2" x="5.7" y="1.75" drill="2.4"/>
+<pad name="P$3" x="-2.25" y="1.75" drill="1.17"/>
+<pad name="P$4" x="2.25" y="1.75" drill="1.17"/>
+<smd name="4" x="-3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="1" x="3.5" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="2" x="1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<smd name="3" x="-1" y="4.35" dx="1.2" dy="2" layer="1"/>
+<wire x1="-6" y1="-1" x2="-6" y2="5" width="0.254" layer="49"/>
+<wire x1="-6" y1="5" x2="6" y2="5" width="0.254" layer="49"/>
+<wire x1="6" y1="5" x2="6" y2="-1" width="0.254" layer="49"/>
+<wire x1="6" y1="-1" x2="-6" y2="-1" width="0.254" layer="49"/>
+<wire x1="-6" y1="-1" x2="-6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="-6" y1="-15.8" x2="6" y2="-15.8" width="0.254" layer="49"/>
+<wire x1="6" y1="-15.8" x2="6" y2="-1" width="0.254" layer="49"/>
+<text x="-2" y="0" size="0.8128" layer="49">&gt;NAME</text>
 </package>
-<package name="USB-A">
-<smd name="VBUS" x="-3.5" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="D-" x="-1" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="D+" x="1" y="0" dx="0.8" dy="2.82" layer="1"/>
-<smd name="GND" x="3.5" y="0" dx="0.8" dy="2.82" layer="1"/>
-<pad name="P$5" x="-6.57" y="-3.71" drill="2.3" diameter="2.3"/>
-<pad name="P$6" x="6.57" y="-3.71" drill="2.3" diameter="2.3"/>
-<wire x1="-6.5" y1="1.2" x2="6.6" y2="1.2" width="0.127" layer="21"/>
-<wire x1="6.6" y1="1.2" x2="6.6" y2="-15" width="0.127" layer="21"/>
-<wire x1="6.6" y1="-15" x2="-6.5" y2="-15" width="0.127" layer="21"/>
-<wire x1="-6.5" y1="-15" x2="-6.5" y2="1.2" width="0.127" layer="21"/>
-<text x="0" y="-14.5" size="1.27" layer="25">&gt;NAME</text>
+<package name="RJ12-VERT">
+<description>Vertical RJ-12 Connector, digikey pn: AE10391-ND</description>
+<pad name="ANCHOR1" x="-5.08" y="0" drill="3.27"/>
+<pad name="ARCHOR2" x="5.08" y="0" drill="3.27"/>
+<pad name="3" x="-0.635" y="8.89" drill="1.17"/>
+<pad name="1" x="-3.175" y="8.89" drill="1.17"/>
+<pad name="5" x="1.905" y="8.89" drill="1.17"/>
+<pad name="6" x="3.175" y="6.35" drill="1.17"/>
+<pad name="4" x="0.635" y="6.35" drill="1.17"/>
+<pad name="2" x="-1.905" y="6.35" drill="1.17"/>
+<wire x1="-7.95" y1="-6.48" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="7.95" y2="10.02" width="0.254" layer="21"/>
+<wire x1="-7.95" y1="10.02" x2="-7.95" y2="-6.48" width="0.254" layer="21"/>
+<wire x1="7.95" y1="10.02" x2="7.95" y2="-6.48" width="0.254" layer="21"/>
+<text x="3" y="-5" size="0.8128" layer="21">&gt;NAME</text>
 </package>
 </packages>
 <symbols>
@@ -436,6 +442,17 @@ reflow soldering</description>
 <text x="6.858" y="-2.032" size="1.27" layer="97">MCP1702</text>
 <text x="9.398" y="-4.826" size="1.27" layer="95">&gt;NAME</text>
 </symbol>
+<symbol name="USB-A">
+<pin name="VCC" x="-2.54" y="7.62" visible="pin" length="short" direction="pwr"/>
+<pin name="D+" x="-2.54" y="5.08" visible="pin" length="short"/>
+<pin name="D-" x="-2.54" y="2.54" visible="pin" length="short"/>
+<pin name="GND" x="-2.54" y="0" visible="pin" length="short" direction="pwr"/>
+<wire x1="0" y1="10.16" x2="0" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.54" x2="7.62" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="7.62" y1="-2.54" x2="7.62" y2="10.16" width="0.254" layer="94"/>
+<wire x1="7.62" y1="10.16" x2="0" y2="10.16" width="0.254" layer="94"/>
+<text x="0" y="-5.08" size="1.27" layer="96">&gt;NAME</text>
+</symbol>
 <symbol name="MOMO-SENSOR-HEADER">
 <pin name="2.8V" x="-5.08" y="5.08" length="short"/>
 <pin name="VBAT" x="-5.08" y="2.54" length="short"/>
@@ -449,17 +466,6 @@ reflow soldering</description>
 <wire x1="-2.54" y1="-15.24" x2="-2.54" y2="7.62" width="0.254" layer="94"/>
 <text x="-2.032" y="-17.272" size="1.27" layer="95">&gt;NAME</text>
 <text x="9.398" y="-15.24" size="1.27" layer="95" rot="R90">Sensor Header</text>
-</symbol>
-<symbol name="USB-A">
-<pin name="VCC" x="-2.54" y="7.62" visible="pin" length="short" direction="pwr"/>
-<pin name="D+" x="-2.54" y="5.08" visible="pin" length="short"/>
-<pin name="D-" x="-2.54" y="2.54" visible="pin" length="short"/>
-<pin name="GND" x="-2.54" y="0" visible="pin" length="short" direction="pwr"/>
-<wire x1="0" y1="10.16" x2="0" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="7.62" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="7.62" y1="-2.54" x2="7.62" y2="10.16" width="0.254" layer="94"/>
-<wire x1="7.62" y1="10.16" x2="0" y2="10.16" width="0.254" layer="94"/>
-<text x="0" y="-5.08" size="1.27" layer="96">&gt;NAME</text>
 </symbol>
 </symbols>
 <devicesets>
@@ -569,7 +575,7 @@ reflow soldering</description>
 </device>
 </devices>
 </deviceset>
-<deviceset name="MCP1702">
+<deviceset name="MCP1702" prefix="U">
 <gates>
 <gate name="G$1" symbol="MCP1702" x="-7.62" y="-5.08"/>
 </gates>
@@ -581,45 +587,56 @@ reflow soldering</description>
 <connect gate="G$1" pin="VOUT" pad="2"/>
 </connects>
 <technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DESCRIPTION" value="MCP1702 2.8V Linear Regulator" constant="no"/>
+<attribute name="DIGIKEY-PN" value="MCP1702T-2802E/CBCT-ND" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>
 </deviceset>
-<deviceset name="MOMO-SENSOR-HEADER">
+<deviceset name="MOLEX-USB-CONN" prefix="JP">
 <gates>
-<gate name="G$1" symbol="MOMO-SENSOR-HEADER" x="-2.54" y="5.08"/>
+<gate name="G$1" symbol="USB-A" x="-2.54" y="-5.08"/>
 </gates>
 <devices>
-<device name="" package="2X3-MOLEX-90130">
+<device name="" package="USB-MALE-EDGE">
+<connects>
+<connect gate="G$1" pin="D+" pad="3"/>
+<connect gate="G$1" pin="D-" pad="2"/>
+<connect gate="G$1" pin="GND" pad="4"/>
+<connect gate="G$1" pin="VCC" pad="1"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="DESCRIPTION" value="USB-A Male Connector PCB Edge Mount" constant="no"/>
+<attribute name="DIGIKEY-PN" value="WM17118-ND" constant="no"/>
+<attribute name="FOOTPRINT" value="SMD + Through Hole" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MOMO-SENSOR-RJ11-VERT" prefix="JP">
+<gates>
+<gate name="G$1" symbol="MOMO-SENSOR-HEADER" x="-2.54" y="2.54"/>
+</gates>
+<devices>
+<device name="" package="RJ12-VERT">
 <connects>
 <connect gate="G$1" pin="2.8V" pad="1"/>
-<connect gate="G$1" pin="ALARM" pad="5"/>
-<connect gate="G$1" pin="CLK" pad="3"/>
-<connect gate="G$1" pin="DATA" pad="4"/>
-<connect gate="G$1" pin="GND" pad="6"/>
-<connect gate="G$1" pin="VBAT" pad="2"/>
+<connect gate="G$1" pin="ALARM" pad="4"/>
+<connect gate="G$1" pin="CLK" pad="2"/>
+<connect gate="G$1" pin="DATA" pad="3"/>
+<connect gate="G$1" pin="GND" pad="5"/>
+<connect gate="G$1" pin="VBAT" pad="6"/>
 </connects>
 <technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="USB-A">
-<gates>
-<gate name="G$1" symbol="USB-A" x="-2.54" y="-2.54"/>
-</gates>
-<devices>
-<device name="" package="USB-A">
-<connects>
-<connect gate="G$1" pin="D+" pad="D+"/>
-<connect gate="G$1" pin="D-" pad="D-"/>
-<connect gate="G$1" pin="GND" pad="GND"/>
-<connect gate="G$1" pin="VCC" pad="VBUS"/>
-</connects>
-<technologies>
-<technology name=""/>
+<technology name="">
+<attribute name="DESCRIPTION" value="Vertical Mount RJ-12 Receptacle" constant="no"/>
+<attribute name="DIGIKEY-PN" value="AE10391-ND" constant="no"/>
+<attribute name="FOOTPRINT" value="Through Hole" constant="no"/>
+</technology>
 </technologies>
 </device>
 </devices>
@@ -6419,172 +6436,6 @@ Source: http://www.murata.com .. GRM43DR72E224KW01.pdf</description>
 </deviceset>
 </devicesets>
 </library>
-<library name="pinhead">
-<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
-&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
-<packages>
-<package name="1X06">
-<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
-<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="3.175" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="3.175" y1="1.27" x2="4.445" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="4.445" y1="1.27" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="0.635" x2="5.08" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="-0.635" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="4.445" y1="-1.27" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="3.175" y1="-1.27" x2="2.54" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="0" y1="-0.635" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-6.985" y1="1.27" x2="-5.715" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="-5.715" y1="1.27" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="0.635" x2="-5.08" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="-0.635" x2="-5.715" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="0.635" x2="-4.445" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="-4.445" y1="1.27" x2="-3.175" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="-3.175" y1="1.27" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="-0.635" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-3.175" y1="-1.27" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-4.445" y1="-1.27" x2="-5.08" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="-7.62" y1="0.635" x2="-7.62" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="-6.985" y1="1.27" x2="-7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-7.62" y1="-0.635" x2="-6.985" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="-5.715" y1="-1.27" x2="-6.985" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="5.715" y1="1.27" x2="6.985" y2="1.27" width="0.1524" layer="21"/>
-<wire x1="6.985" y1="1.27" x2="7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="0.635" x2="7.62" y2="-0.635" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="-0.635" x2="6.985" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="5.715" y1="1.27" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="-0.635" x2="5.715" y2="-1.27" width="0.1524" layer="21"/>
-<wire x1="6.985" y1="-1.27" x2="5.715" y2="-1.27" width="0.1524" layer="21"/>
-<pad name="1" x="-6.35" y="0" drill="1.016" shape="long" rot="R90"/>
-<pad name="2" x="-3.81" y="0" drill="1.016" shape="long" rot="R90"/>
-<pad name="3" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
-<pad name="4" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
-<pad name="5" x="3.81" y="0" drill="1.016" shape="long" rot="R90"/>
-<pad name="6" x="6.35" y="0" drill="1.016" shape="long" rot="R90"/>
-<text x="-7.6962" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
-<text x="-7.62" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
-<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
-<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
-<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
-<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
-<rectangle x1="-6.604" y1="-0.254" x2="-6.096" y2="0.254" layer="51"/>
-<rectangle x1="6.096" y1="-0.254" x2="6.604" y2="0.254" layer="51"/>
-</package>
-<package name="1X06/90">
-<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
-<wire x1="-7.62" y1="-1.905" x2="-5.08" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="-1.905" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-5.08" y1="0.635" x2="-7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-7.62" y1="0.635" x2="-7.62" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-6.35" y1="6.985" x2="-6.35" y2="1.27" width="0.762" layer="21"/>
-<wire x1="-5.08" y1="-1.905" x2="-2.54" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="-1.905" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-2.54" y1="0.635" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-3.81" y1="6.985" x2="-3.81" y2="1.27" width="0.762" layer="21"/>
-<wire x1="-2.54" y1="-1.905" x2="0" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="0" y1="-1.905" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="0" y1="0.635" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="-1.27" y1="6.985" x2="-1.27" y2="1.27" width="0.762" layer="21"/>
-<wire x1="0" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="2.54" y1="0.635" x2="0" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="1.27" y1="6.985" x2="1.27" y2="1.27" width="0.762" layer="21"/>
-<wire x1="2.54" y1="-1.905" x2="5.08" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="-1.905" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="5.08" y1="0.635" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="3.81" y1="6.985" x2="3.81" y2="1.27" width="0.762" layer="21"/>
-<wire x1="5.08" y1="-1.905" x2="7.62" y2="-1.905" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="-1.905" x2="7.62" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="7.62" y1="0.635" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
-<wire x1="6.35" y1="6.985" x2="6.35" y2="1.27" width="0.762" layer="21"/>
-<pad name="1" x="-6.35" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="2" x="-3.81" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="3" x="-1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="4" x="1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="5" x="3.81" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<pad name="6" x="6.35" y="-3.81" drill="1.016" shape="long" rot="R90"/>
-<text x="-8.255" y="-3.81" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
-<text x="9.525" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
-<rectangle x1="-6.731" y1="0.635" x2="-5.969" y2="1.143" layer="21"/>
-<rectangle x1="-4.191" y1="0.635" x2="-3.429" y2="1.143" layer="21"/>
-<rectangle x1="-1.651" y1="0.635" x2="-0.889" y2="1.143" layer="21"/>
-<rectangle x1="0.889" y1="0.635" x2="1.651" y2="1.143" layer="21"/>
-<rectangle x1="3.429" y1="0.635" x2="4.191" y2="1.143" layer="21"/>
-<rectangle x1="5.969" y1="0.635" x2="6.731" y2="1.143" layer="21"/>
-<rectangle x1="-6.731" y1="-2.921" x2="-5.969" y2="-1.905" layer="21"/>
-<rectangle x1="-4.191" y1="-2.921" x2="-3.429" y2="-1.905" layer="21"/>
-<rectangle x1="-1.651" y1="-2.921" x2="-0.889" y2="-1.905" layer="21"/>
-<rectangle x1="0.889" y1="-2.921" x2="1.651" y2="-1.905" layer="21"/>
-<rectangle x1="3.429" y1="-2.921" x2="4.191" y2="-1.905" layer="21"/>
-<rectangle x1="5.969" y1="-2.921" x2="6.731" y2="-1.905" layer="21"/>
-</package>
-</packages>
-<symbols>
-<symbol name="PINHD6">
-<wire x1="-6.35" y1="-7.62" x2="1.27" y2="-7.62" width="0.4064" layer="94"/>
-<wire x1="1.27" y1="-7.62" x2="1.27" y2="10.16" width="0.4064" layer="94"/>
-<wire x1="1.27" y1="10.16" x2="-6.35" y2="10.16" width="0.4064" layer="94"/>
-<wire x1="-6.35" y1="10.16" x2="-6.35" y2="-7.62" width="0.4064" layer="94"/>
-<text x="-6.35" y="10.795" size="1.778" layer="95">&gt;NAME</text>
-<text x="-6.35" y="-10.16" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="1" x="-2.54" y="7.62" visible="pad" length="short" direction="pas" function="dot"/>
-<pin name="2" x="-2.54" y="5.08" visible="pad" length="short" direction="pas" function="dot"/>
-<pin name="3" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" function="dot"/>
-<pin name="4" x="-2.54" y="0" visible="pad" length="short" direction="pas" function="dot"/>
-<pin name="5" x="-2.54" y="-2.54" visible="pad" length="short" direction="pas" function="dot"/>
-<pin name="6" x="-2.54" y="-5.08" visible="pad" length="short" direction="pas" function="dot"/>
-</symbol>
-</symbols>
-<devicesets>
-<deviceset name="PINHD-1X6" prefix="JP" uservalue="yes">
-<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
-<gates>
-<gate name="A" symbol="PINHD6" x="0" y="-2.54"/>
-</gates>
-<devices>
-<device name="" package="1X06">
-<connects>
-<connect gate="A" pin="1" pad="1"/>
-<connect gate="A" pin="2" pad="2"/>
-<connect gate="A" pin="3" pad="3"/>
-<connect gate="A" pin="4" pad="4"/>
-<connect gate="A" pin="5" pad="5"/>
-<connect gate="A" pin="6" pad="6"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-<device name="/90" package="1X06/90">
-<connects>
-<connect gate="A" pin="1" pad="1"/>
-<connect gate="A" pin="2" pad="2"/>
-<connect gate="A" pin="3" pad="3"/>
-<connect gate="A" pin="4" pad="4"/>
-<connect gate="A" pin="5" pad="5"/>
-<connect gate="A" pin="6" pad="6"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-</devicesets>
-</library>
 <library name="led">
 <description>&lt;b&gt;LEDs&lt;/b&gt;&lt;p&gt;
 &lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;&lt;br&gt;
@@ -8090,6 +7941,153 @@ Source: www.kingbright.com</description>
 </deviceset>
 </devicesets>
 </library>
+<library name="pinhead">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X05">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="1.905" y1="1.27" x2="3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="1.27" x2="-4.445" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="1.27" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-0.635" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-1.27" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-1.27" x2="-3.81" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="0.635" x2="-6.35" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="1.27" x2="-6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="-0.635" x2="-5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="-1.27" x2="-5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.715" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="5.715" y1="1.27" x2="6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="6.35" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="-0.635" x2="5.715" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-0.635" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="5.715" y1="-1.27" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="0" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="2.54" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="5" x="5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.4262" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-6.35" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="2.286" y1="-0.254" x2="2.794" y2="0.254" layer="51"/>
+<rectangle x1="-0.254" y1="-0.254" x2="0.254" y2="0.254" layer="51"/>
+<rectangle x1="-2.794" y1="-0.254" x2="-2.286" y2="0.254" layer="51"/>
+<rectangle x1="-5.334" y1="-0.254" x2="-4.826" y2="0.254" layer="51"/>
+<rectangle x1="4.826" y1="-0.254" x2="5.334" y2="0.254" layer="51"/>
+</package>
+<package name="1X05/90">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-6.35" y1="-1.905" x2="-3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="-1.905" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-3.81" y1="0.635" x2="-6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-6.35" y1="0.635" x2="-6.35" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="6.985" x2="-5.08" y2="1.27" width="0.762" layer="21"/>
+<wire x1="-3.81" y1="-1.905" x2="-1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="-1.905" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="0.635" x2="-3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="6.985" x2="-2.54" y2="1.27" width="0.762" layer="21"/>
+<wire x1="-1.27" y1="-1.905" x2="1.27" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="-1.905" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="0.635" x2="-1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="6.985" x2="0" y2="1.27" width="0.762" layer="21"/>
+<wire x1="1.27" y1="-1.905" x2="3.81" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="-1.905" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="3.81" y1="0.635" x2="1.27" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="6.985" x2="2.54" y2="1.27" width="0.762" layer="21"/>
+<wire x1="3.81" y1="-1.905" x2="6.35" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="-1.905" x2="6.35" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="6.35" y1="0.635" x2="3.81" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="6.985" x2="5.08" y2="1.27" width="0.762" layer="21"/>
+<pad name="1" x="-5.08" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-2.54" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="0" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="2.54" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="5" x="5.08" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.985" y="-3.81" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="8.255" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+<rectangle x1="-5.461" y1="0.635" x2="-4.699" y2="1.143" layer="21"/>
+<rectangle x1="-2.921" y1="0.635" x2="-2.159" y2="1.143" layer="21"/>
+<rectangle x1="-0.381" y1="0.635" x2="0.381" y2="1.143" layer="21"/>
+<rectangle x1="2.159" y1="0.635" x2="2.921" y2="1.143" layer="21"/>
+<rectangle x1="4.699" y1="0.635" x2="5.461" y2="1.143" layer="21"/>
+<rectangle x1="-5.461" y1="-2.921" x2="-4.699" y2="-1.905" layer="21"/>
+<rectangle x1="-2.921" y1="-2.921" x2="-2.159" y2="-1.905" layer="21"/>
+<rectangle x1="-0.381" y1="-2.921" x2="0.381" y2="-1.905" layer="21"/>
+<rectangle x1="2.159" y1="-2.921" x2="2.921" y2="-1.905" layer="21"/>
+<rectangle x1="4.699" y1="-2.921" x2="5.461" y2="-1.905" layer="21"/>
+</package>
+</packages>
+<symbols>
+<symbol name="PINHD5">
+<wire x1="-6.35" y1="-7.62" x2="1.27" y2="-7.62" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-7.62" x2="1.27" y2="7.62" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="7.62" x2="-6.35" y2="7.62" width="0.4064" layer="94"/>
+<wire x1="-6.35" y1="7.62" x2="-6.35" y2="-7.62" width="0.4064" layer="94"/>
+<text x="-6.35" y="8.255" size="1.778" layer="95">&gt;NAME</text>
+<text x="-6.35" y="-10.16" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="1" x="-2.54" y="5.08" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="2" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="3" x="-2.54" y="0" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="4" x="-2.54" y="-2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="5" x="-2.54" y="-5.08" visible="pad" length="short" direction="pas" function="dot"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PINHD-1X5" prefix="JP" uservalue="yes">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<gates>
+<gate name="A" symbol="PINHD5" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X05">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+<connect gate="A" pin="3" pad="3"/>
+<connect gate="A" pin="4" pad="4"/>
+<connect gate="A" pin="5" pad="5"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="/90" package="1X05/90">
+<connects>
+<connect gate="A" pin="1" pad="1"/>
+<connect gate="A" pin="2" pad="2"/>
+<connect gate="A" pin="3" pad="3"/>
+<connect gate="A" pin="4" pad="4"/>
+<connect gate="A" pin="5" pad="5"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
 </libraries>
 <attributes>
 </attributes>
@@ -8102,15 +8100,37 @@ Source: www.kingbright.com</description>
 <parts>
 <part name="GND1" library="supply1" deviceset="GND" device=""/>
 <part name="P+1" library="supply1" deviceset="+5V" device=""/>
-<part name="U1" library="components" deviceset="FTDI-230X" device=""/>
-<part name="FB1" library="components" deviceset="FERRITE" device=""/>
-<part name="C1" library="rcl" deviceset="C-US" device="C0402" value="10nF"/>
-<part name="C2" library="rcl" deviceset="C-US" device="C0402" value="100nF"/>
-<part name="C3" library="rcl" deviceset="C-US" device="C0805" value="4.7uF"/>
-<part name="C4" library="rcl" deviceset="C-US" device="C0402" value="47pF"/>
-<part name="C5" library="rcl" deviceset="C-US" device="C0402" value="47pF"/>
-<part name="R1" library="rcl" deviceset="R-US_" device="R0603" value="27R"/>
-<part name="R2" library="rcl" deviceset="R-US_" device="R0603" value="27R"/>
+<part name="U1" library="components" deviceset="FTDI-230X" device="">
+<attribute name="DESCRIPTION" value="FTDI-230X USB-Serial Adapter IC"/>
+<attribute name="DIGIKEY-PN" value="768-1135-1-ND"/>
+<attribute name="FOOTPRINT" value="SSOP16"/>
+</part>
+<part name="FB1" library="components" deviceset="FERRITE" device="">
+<attribute name="DESCRIPTION" value="Ferrite Bead"/>
+<attribute name="DIGIKEY-PN" value="240-2390-1-ND"/>
+<attribute name="FOOTPRINT" value="SMD 0805"/>
+</part>
+<part name="C1" library="rcl" deviceset="C-US" device="C0402" value="10nF">
+<attribute name="DIGIKEY-PN" value="1276-1499-1-ND"/>
+</part>
+<part name="C2" library="rcl" deviceset="C-US" device="C0402" value="100nF">
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND"/>
+</part>
+<part name="C3" library="rcl" deviceset="C-US" device="C0805" value="4.7uF">
+<attribute name="DIGIKEY-PN" value="445-1605-1-ND"/>
+</part>
+<part name="C4" library="rcl" deviceset="C-US" device="C0402" value="47pF">
+<attribute name="DIGIKEY-PN" value="1276-1699-1-ND"/>
+</part>
+<part name="C5" library="rcl" deviceset="C-US" device="C0402" value="47pF">
+<attribute name="DIGIKEY-PN" value="1276-1699-1-ND"/>
+</part>
+<part name="R1" library="rcl" deviceset="R-US_" device="R0603" value="27R">
+<attribute name="DIGIKEY-PN" value="P27.0HCT-ND"/>
+</part>
+<part name="R2" library="rcl" deviceset="R-US_" device="R0603" value="27R">
+<attribute name="DIGIKEY-PN" value="P27.0HCT-ND"/>
+</part>
 <part name="GND2" library="supply1" deviceset="GND" device=""/>
 <part name="GND3" library="supply1" deviceset="GND" device=""/>
 <part name="GND4" library="supply1" deviceset="GND" device=""/>
@@ -8124,49 +8144,72 @@ Source: www.kingbright.com</description>
 <part name="+3V1" library="supply1" deviceset="+3V3" device=""/>
 <part name="GND8" library="supply1" deviceset="GND" device=""/>
 <part name="P+6" library="supply1" deviceset="V+" device=""/>
-<part name="J2" library="pinhead" deviceset="PINHD-1X6" device="/90"/>
-<part name="U3" library="components" deviceset="PIC24F16KA101-X_P" device="SSOP"/>
-<part name="C6" library="rcl" deviceset="C-US" device="C0402" value="100 nF"/>
+<part name="U3" library="components" deviceset="PIC24F16KA101-X_P" device="SSOP">
+<attribute name="DESCRIPTION" value="PIC 24F16KA101 16-bit Microprocessor"/>
+<attribute name="DIGIKEY-PN" value="PIC24F16KA101-I/SS-ND"/>
+<attribute name="FOOTPRINT" value="SSOP20"/>
+</part>
+<part name="C6" library="rcl" deviceset="C-US" device="C0402" value="100 nF">
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND"/>
+</part>
 <part name="VCC1" library="supply1" deviceset="VCCIO" device=""/>
 <part name="GND13" library="supply1" deviceset="GND" device=""/>
 <part name="GND14" library="supply1" deviceset="GND" device=""/>
 <part name="U2" library="components" deviceset="MCP1702" device=""/>
-<part name="C8" library="rcl" deviceset="C-US" device="C0402" value="1 uF"/>
+<part name="C8" library="rcl" deviceset="C-US" device="C0402" value="1 uF">
+<attribute name="DIGIKEY-PN" value="1276-1076-1-ND"/>
+</part>
 <part name="GND16" library="supply1" deviceset="GND" device=""/>
 <part name="GND17" library="supply1" deviceset="GND" device=""/>
 <part name="P+7" library="supply1" deviceset="+5V" device=""/>
 <part name="VCC2" library="supply1" deviceset="VCCIO" device=""/>
-<part name="VCC3" library="supply1" deviceset="VCCIO" device=""/>
-<part name="R4" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
+<part name="VCC3" library="supply1" deviceset="VCCIO" device="">
+<attribute name="DIGIKEY-PN" value="1276-1699-1-ND"/>
+</part>
+<part name="R4" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
 <part name="VCC4" library="supply1" deviceset="VCCIO" device=""/>
 <part name="VCC5" library="supply1" deviceset="VCCIO" device=""/>
 <part name="GND18" library="supply1" deviceset="GND" device=""/>
 <part name="P+8" library="supply1" deviceset="V+" device=""/>
-<part name="+3V4" library="supply1" deviceset="+3V3" device=""/>
-<part name="R6" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
-<part name="R7" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
-<part name="R8" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
-<part name="R9" library="rcl" deviceset="R-US_" device="R0603" value="1K"/>
-<part name="C9" library="rcl" deviceset="C-US" device="C0402" value="100 nF"/>
-<part name="C7" library="rcl" deviceset="C-US" device="C0402" value="100nF"/>
+<part name="R6" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
+<part name="R7" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
+<part name="C7" library="rcl" deviceset="C-US" device="C0402" value="100nF">
+<attribute name="DIGIKEY-PN" value="445-1265-1-ND"/>
+</part>
 <part name="GND19" library="supply1" deviceset="GND" device=""/>
-<part name="GND21" library="supply1" deviceset="GND" device=""/>
-<part name="R5" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
-<part name="R10" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
+<part name="R5" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
+<part name="R10" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
 <part name="+3V6" library="supply1" deviceset="+3V3" device=""/>
 <part name="+3V7" library="supply1" deviceset="+3V3" device=""/>
-<part name="LED1" library="led" deviceset="LED" device="5MM"/>
-<part name="R11" library="rcl" deviceset="R-US_" device="R0603" value="66R"/>
-<part name="GND20" library="supply1" deviceset="GND" device=""/>
-<part name="VCC7" library="supply1" deviceset="VCCIO" device=""/>
-<part name="LED2" library="led" deviceset="LED" device="5MM"/>
-<part name="R12" library="rcl" deviceset="R-US_" device="R0603" value="66R"/>
+<part name="R12" library="rcl" deviceset="R-US_" device="R0603" value="68R">
+<attribute name="DIGIKEY-PN" value="P68GCT-ND"/>
+</part>
 <part name="+3V8" library="supply1" deviceset="+3V3" device=""/>
 <part name="GND22" library="supply1" deviceset="GND" device=""/>
-<part name="R3" library="rcl" deviceset="R-US_" device="R0603" value="10K"/>
+<part name="R3" library="rcl" deviceset="R-US_" device="R0603" value="10K">
+<attribute name="DIGIKEY-PN" value="P10.0KHCT-ND"/>
+</part>
 <part name="+3V2" library="supply1" deviceset="+3V3" device=""/>
-<part name="J3" library="components" deviceset="MOMO-SENSOR-HEADER" device=""/>
-<part name="USB1" library="components" deviceset="USB-A" device=""/>
+<part name="JP1" library="components" deviceset="MOLEX-USB-CONN" device=""/>
+<part name="LED2" library="led" deviceset="LED" device="SML0603">
+<attribute name="DESCRIPTION" value="Green Chip LED"/>
+<attribute name="DIGIKEY-PN" value="475-1409-1-ND"/>
+<attribute name="FOOTPRINT" value="SMD 0603"/>
+</part>
+<part name="JP3" library="components" deviceset="MOMO-SENSOR-RJ11-VERT" device=""/>
+<part name="JP2" library="pinhead" deviceset="PINHD-1X5" device="">
+<attribute name="POPULATE" value="NO"/>
+</part>
 </parts>
 <sheets>
 <sheet>
@@ -8196,22 +8239,44 @@ Source: www.kingbright.com</description>
 <text x="-13.97" y="-92.71" size="1.778" layer="97">Title</text>
 <text x="1.27" y="-92.71" size="1.778" layer="97">Momo Field Service Unit</text>
 <text x="-13.97" y="-101.6" size="1.778" layer="97">Notes</text>
-<text x="1.27" y="-104.14" size="1.778" layer="97">Version 2.0
-7/19/2013</text>
+<text x="1.27" y="-104.14" size="1.778" layer="97">Version 3.0
+3/19/2014</text>
 <text x="0" y="-87.63" size="1.778" layer="97">Design Information</text>
 </plain>
 <instances>
 <instance part="GND1" gate="1" x="17.78" y="35.56"/>
 <instance part="P+1" gate="1" x="20.32" y="76.2"/>
-<instance part="U1" gate="G$1" x="66.04" y="48.26"/>
-<instance part="FB1" gate="G$1" x="20.32" y="60.96" rot="R90"/>
-<instance part="C1" gate="G$1" x="45.72" y="111.76"/>
-<instance part="C2" gate="G$1" x="55.88" y="111.76"/>
-<instance part="C3" gate="G$1" x="66.04" y="111.76"/>
-<instance part="C4" gate="G$1" x="30.48" y="43.18"/>
-<instance part="C5" gate="G$1" x="40.64" y="43.18"/>
-<instance part="R1" gate="G$1" x="50.8" y="50.8"/>
-<instance part="R2" gate="G$1" x="50.8" y="48.26"/>
+<instance part="U1" gate="G$1" x="66.04" y="48.26">
+<attribute name="DIGIKEY-PN" x="66.04" y="48.26" size="1.778" layer="96" display="off"/>
+<attribute name="DESCRIPTION" x="66.04" y="48.26" size="1.778" layer="96" display="off"/>
+<attribute name="FOOTPRINT" x="66.04" y="48.26" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="FB1" gate="G$1" x="20.32" y="60.96" rot="R90">
+<attribute name="DIGIKEY-PN" x="20.32" y="60.96" size="1.778" layer="96" rot="R90" display="off"/>
+<attribute name="DESCRIPTION" x="20.32" y="60.96" size="1.778" layer="96" rot="R90" display="off"/>
+<attribute name="FOOTPRINT" x="20.32" y="60.96" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
+<instance part="C1" gate="G$1" x="45.72" y="111.76">
+<attribute name="DIGIKEY-PN" x="45.72" y="111.76" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C2" gate="G$1" x="55.88" y="111.76">
+<attribute name="DIGIKEY-PN" x="55.88" y="111.76" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C3" gate="G$1" x="66.04" y="111.76">
+<attribute name="DIGIKEY-PN" x="66.04" y="111.76" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C4" gate="G$1" x="30.48" y="43.18">
+<attribute name="DIGIKEY-PN" x="30.48" y="43.18" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C5" gate="G$1" x="40.64" y="43.18">
+<attribute name="DIGIKEY-PN" x="40.64" y="43.18" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="R1" gate="G$1" x="50.8" y="50.8">
+<attribute name="DIGIKEY-PN" x="50.8" y="50.8" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="R2" gate="G$1" x="50.8" y="48.26">
+<attribute name="DIGIKEY-PN" x="50.8" y="48.26" size="1.778" layer="96" display="off"/>
+</instance>
 <instance part="GND2" gate="1" x="30.48" y="35.56"/>
 <instance part="GND3" gate="1" x="40.64" y="35.56"/>
 <instance part="GND4" gate="1" x="45.72" y="104.14"/>
@@ -8225,49 +8290,72 @@ Source: www.kingbright.com</description>
 <instance part="+3V1" gate="G$1" x="251.46" y="73.66"/>
 <instance part="GND8" gate="1" x="254" y="35.56"/>
 <instance part="P+6" gate="1" x="243.84" y="73.66"/>
-<instance part="J2" gate="A" x="302.26" y="-60.96"/>
-<instance part="U3" gate="A" x="137.16" y="-35.56"/>
-<instance part="C6" gate="G$1" x="129.54" y="-71.12"/>
+<instance part="U3" gate="A" x="137.16" y="-35.56">
+<attribute name="DIGIKEY-PN" x="137.16" y="-35.56" size="1.778" layer="96" display="off"/>
+<attribute name="DESCRIPTION" x="137.16" y="-35.56" size="1.778" layer="96" display="off"/>
+<attribute name="FOOTPRINT" x="137.16" y="-35.56" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="C6" gate="G$1" x="129.54" y="-71.12">
+<attribute name="DIGIKEY-PN" x="129.54" y="-71.12" size="1.778" layer="96" display="off"/>
+</instance>
 <instance part="VCC1" gate="G$1" x="129.54" y="-66.04"/>
 <instance part="GND13" gate="1" x="129.54" y="-78.74"/>
 <instance part="GND14" gate="1" x="254" y="-71.12"/>
 <instance part="U2" gate="G$1" x="5.08" y="109.22"/>
-<instance part="C8" gate="G$1" x="30.48" y="114.3"/>
+<instance part="C8" gate="G$1" x="30.48" y="114.3">
+<attribute name="DIGIKEY-PN" x="30.48" y="114.3" size="1.778" layer="96" display="off"/>
+</instance>
 <instance part="GND16" gate="1" x="12.7" y="99.06"/>
 <instance part="GND17" gate="1" x="30.48" y="106.68"/>
 <instance part="P+7" gate="1" x="-7.62" y="119.38"/>
 <instance part="VCC2" gate="G$1" x="30.48" y="119.38"/>
-<instance part="VCC3" gate="G$1" x="81.28" y="71.12"/>
-<instance part="R4" gate="G$1" x="121.92" y="-30.48" rot="R90"/>
+<instance part="VCC3" gate="G$1" x="81.28" y="71.12">
+<attribute name="DIGIKEY-PN" x="81.28" y="71.12" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="R4" gate="G$1" x="121.92" y="-30.48" rot="R90">
+<attribute name="DIGIKEY-PN" x="121.92" y="-30.48" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
 <instance part="VCC4" gate="G$1" x="121.92" y="-22.86"/>
 <instance part="VCC5" gate="G$1" x="314.96" y="-60.96"/>
 <instance part="GND18" gate="1" x="287.02" y="-78.74"/>
 <instance part="P+8" gate="1" x="55.88" y="-12.7"/>
-<instance part="+3V4" gate="G$1" x="76.2" y="-12.7"/>
-<instance part="R6" gate="G$1" x="55.88" y="-27.94" rot="R90"/>
-<instance part="R7" gate="G$1" x="55.88" y="-38.1" rot="R90"/>
-<instance part="R8" gate="G$1" x="76.2" y="-38.1" rot="R90"/>
-<instance part="R9" gate="G$1" x="76.2" y="-27.94" rot="R90"/>
-<instance part="C9" gate="G$1" x="81.28" y="-35.56"/>
-<instance part="C7" gate="G$1" x="60.96" y="-35.56"/>
+<instance part="R6" gate="G$1" x="55.88" y="-27.94" rot="R90">
+<attribute name="DIGIKEY-PN" x="55.88" y="-27.94" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
+<instance part="R7" gate="G$1" x="55.88" y="-38.1" rot="R90">
+<attribute name="DIGIKEY-PN" x="55.88" y="-38.1" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
+<instance part="C7" gate="G$1" x="60.96" y="-35.56">
+<attribute name="DIGIKEY-PN" x="60.96" y="-35.56" size="1.778" layer="96" display="off"/>
+</instance>
 <instance part="GND19" gate="1" x="55.88" y="-45.72"/>
-<instance part="GND21" gate="1" x="76.2" y="-45.72"/>
-<instance part="R5" gate="G$1" x="205.74" y="81.28" rot="R90"/>
-<instance part="R10" gate="G$1" x="213.36" y="81.28" rot="R90"/>
+<instance part="R5" gate="G$1" x="205.74" y="81.28" rot="R90">
+<attribute name="DIGIKEY-PN" x="205.74" y="81.28" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
+<instance part="R10" gate="G$1" x="213.36" y="81.28" rot="R90">
+<attribute name="DIGIKEY-PN" x="213.36" y="81.28" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
 <instance part="+3V6" gate="G$1" x="205.74" y="88.9"/>
 <instance part="+3V7" gate="G$1" x="213.36" y="88.9"/>
-<instance part="LED1" gate="G$1" x="81.28" y="104.14"/>
-<instance part="R11" gate="G$1" x="81.28" y="111.76" rot="R90"/>
-<instance part="GND20" gate="1" x="81.28" y="96.52"/>
-<instance part="VCC7" gate="G$1" x="81.28" y="119.38"/>
-<instance part="LED2" gate="G$1" x="93.98" y="104.14"/>
-<instance part="R12" gate="G$1" x="93.98" y="111.76" rot="R90"/>
+<instance part="R12" gate="G$1" x="93.98" y="111.76" rot="R90">
+<attribute name="DIGIKEY-PN" x="93.98" y="111.76" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
 <instance part="+3V8" gate="G$1" x="93.98" y="119.38"/>
 <instance part="GND22" gate="1" x="93.98" y="96.52"/>
-<instance part="R3" gate="G$1" x="198.12" y="81.28" rot="R90"/>
+<instance part="R3" gate="G$1" x="198.12" y="81.28" rot="R90">
+<attribute name="DIGIKEY-PN" x="198.12" y="81.28" size="1.778" layer="96" rot="R90" display="off"/>
+</instance>
 <instance part="+3V2" gate="G$1" x="198.12" y="88.9"/>
-<instance part="J3" gate="G$1" x="261.62" y="60.96"/>
-<instance part="USB1" gate="G$1" x="12.7" y="53.34" rot="R180"/>
+<instance part="JP1" gate="G$1" x="12.7" y="53.34" rot="R180"/>
+<instance part="LED2" gate="G$1" x="93.98" y="104.14">
+<attribute name="DIGIKEY-PN" x="93.98" y="104.14" size="1.778" layer="96" display="off"/>
+<attribute name="DESCRIPTION" x="93.98" y="104.14" size="1.778" layer="96" display="off"/>
+<attribute name="FOOTPRINT" x="93.98" y="104.14" size="1.778" layer="96" display="off"/>
+</instance>
+<instance part="JP3" gate="G$1" x="261.62" y="60.96"/>
+<instance part="JP2" gate="A" x="302.26" y="-60.96">
+<attribute name="POPULATE" x="302.26" y="-60.96" size="1.778" layer="96" display="off"/>
+</instance>
 </instances>
 <busses>
 <bus name="SIGNALS:DATA,CLOCK,ALARM">
@@ -8286,7 +8374,7 @@ Source: www.kingbright.com</description>
 <pinref part="GND1" gate="1" pin="GND"/>
 <wire x1="15.24" y1="53.34" x2="17.78" y2="53.34" width="0.1524" layer="91"/>
 <wire x1="17.78" y1="53.34" x2="17.78" y2="38.1" width="0.1524" layer="91"/>
-<pinref part="USB1" gate="G$1" pin="GND"/>
+<pinref part="JP1" gate="G$1" pin="GND"/>
 </segment>
 <segment>
 <pinref part="C4" gate="G$1" pin="2"/>
@@ -8316,7 +8404,7 @@ Source: www.kingbright.com</description>
 <pinref part="GND8" gate="1" pin="GND"/>
 <wire x1="254" y1="48.26" x2="254" y2="38.1" width="0.1524" layer="91"/>
 <wire x1="254" y1="48.26" x2="256.54" y2="48.26" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="GND"/>
+<pinref part="JP3" gate="G$1" pin="GND"/>
 </segment>
 <segment>
 <pinref part="C6" gate="G$1" pin="2"/>
@@ -8335,10 +8423,10 @@ Source: www.kingbright.com</description>
 <pinref part="GND17" gate="1" pin="GND"/>
 </segment>
 <segment>
-<pinref part="J2" gate="A" pin="4"/>
 <wire x1="299.72" y1="-60.96" x2="287.02" y2="-60.96" width="0.1524" layer="91"/>
 <wire x1="287.02" y1="-60.96" x2="287.02" y2="-76.2" width="0.1524" layer="91"/>
 <pinref part="GND18" gate="1" pin="GND"/>
+<pinref part="JP2" gate="A" pin="3"/>
 </segment>
 <segment>
 <pinref part="R7" gate="G$1" pin="1"/>
@@ -8349,20 +8437,8 @@ Source: www.kingbright.com</description>
 <junction x="55.88" y="-43.18"/>
 </segment>
 <segment>
-<pinref part="R8" gate="G$1" pin="1"/>
-<pinref part="GND21" gate="1" pin="GND"/>
-<pinref part="C9" gate="G$1" pin="2"/>
-<wire x1="81.28" y1="-40.64" x2="81.28" y2="-43.18" width="0.1524" layer="91"/>
-<wire x1="81.28" y1="-43.18" x2="76.2" y2="-43.18" width="0.1524" layer="91"/>
-<junction x="76.2" y="-43.18"/>
-</segment>
-<segment>
-<pinref part="LED1" gate="G$1" pin="C"/>
-<pinref part="GND20" gate="1" pin="GND"/>
-</segment>
-<segment>
-<pinref part="LED2" gate="G$1" pin="C"/>
 <pinref part="GND22" gate="1" pin="GND"/>
+<pinref part="LED2" gate="G$1" pin="C"/>
 </segment>
 </net>
 <net name="N$2" class="0">
@@ -8370,7 +8446,7 @@ Source: www.kingbright.com</description>
 <wire x1="15.24" y1="45.72" x2="20.32" y2="45.72" width="0.1524" layer="91"/>
 <pinref part="FB1" gate="G$1" pin="IN"/>
 <wire x1="20.32" y1="45.72" x2="20.32" y2="63.5" width="0.1524" layer="91"/>
-<pinref part="USB1" gate="G$1" pin="VCC"/>
+<pinref part="JP1" gate="G$1" pin="VCC"/>
 </segment>
 </net>
 <net name="+5V" class="0">
@@ -8412,7 +8488,7 @@ Source: www.kingbright.com</description>
 <wire x1="40.64" y1="48.26" x2="45.72" y2="48.26" width="0.1524" layer="91"/>
 <wire x1="40.64" y1="45.72" x2="40.64" y2="48.26" width="0.1524" layer="91"/>
 <junction x="40.64" y="48.26"/>
-<pinref part="USB1" gate="G$1" pin="D+"/>
+<pinref part="JP1" gate="G$1" pin="D+"/>
 </segment>
 </net>
 <net name="N$1" class="0">
@@ -8423,7 +8499,7 @@ Source: www.kingbright.com</description>
 <wire x1="30.48" y1="50.8" x2="45.72" y2="50.8" width="0.1524" layer="91"/>
 <wire x1="30.48" y1="45.72" x2="30.48" y2="50.8" width="0.1524" layer="91"/>
 <junction x="30.48" y="50.8"/>
-<pinref part="USB1" gate="G$1" pin="D-"/>
+<pinref part="JP1" gate="G$1" pin="D-"/>
 </segment>
 </net>
 <net name="N$4" class="0">
@@ -8450,15 +8526,10 @@ Source: www.kingbright.com</description>
 <pinref part="P+6" gate="1" pin="V+"/>
 <wire x1="256.54" y1="63.5" x2="243.84" y2="63.5" width="0.1524" layer="91"/>
 <wire x1="243.84" y1="63.5" x2="243.84" y2="71.12" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="VBAT"/>
+<pinref part="JP3" gate="G$1" pin="VBAT"/>
 </segment>
 </net>
 <net name="+3V3" class="0">
-<segment>
-<pinref part="R9" gate="G$1" pin="2"/>
-<pinref part="+3V4" gate="G$1" pin="+3V3"/>
-<wire x1="76.2" y1="-22.86" x2="76.2" y2="-15.24" width="0.1524" layer="91"/>
-</segment>
 <segment>
 <pinref part="R5" gate="G$1" pin="2"/>
 <pinref part="+3V6" gate="G$1" pin="+3V3"/>
@@ -8475,7 +8546,7 @@ Source: www.kingbright.com</description>
 <pinref part="+3V1" gate="G$1" pin="+3V3"/>
 <wire x1="251.46" y1="71.12" x2="251.46" y2="66.04" width="0.1524" layer="91"/>
 <wire x1="251.46" y1="66.04" x2="256.54" y2="66.04" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="2.8V"/>
+<pinref part="JP3" gate="G$1" pin="2.8V"/>
 </segment>
 <segment>
 <pinref part="R3" gate="G$1" pin="2"/>
@@ -8508,16 +8579,12 @@ Source: www.kingbright.com</description>
 <pinref part="VCC4" gate="G$1" pin="VCCIO"/>
 </segment>
 <segment>
-<pinref part="J2" gate="A" pin="5"/>
 <wire x1="299.72" y1="-63.5" x2="292.1" y2="-63.5" width="0.1524" layer="91"/>
 <wire x1="292.1" y1="-63.5" x2="292.1" y2="-71.12" width="0.1524" layer="91"/>
 <pinref part="VCC5" gate="G$1" pin="VCCIO"/>
 <wire x1="292.1" y1="-71.12" x2="314.96" y2="-71.12" width="0.1524" layer="91"/>
 <wire x1="314.96" y1="-71.12" x2="314.96" y2="-63.5" width="0.1524" layer="91"/>
-</segment>
-<segment>
-<pinref part="R11" gate="G$1" pin="2"/>
-<pinref part="VCC7" gate="G$1" pin="VCCIO"/>
+<pinref part="JP2" gate="A" pin="4"/>
 </segment>
 </net>
 <net name="N$21" class="0">
@@ -8525,15 +8592,12 @@ Source: www.kingbright.com</description>
 <pinref part="R4" gate="G$1" pin="1"/>
 <pinref part="U3" gate="A" pin="*MCLR/VPP/RA5"/>
 <wire x1="121.92" y1="-35.56" x2="139.7" y2="-35.56" width="0.1524" layer="91"/>
-<pinref part="J2" gate="A" pin="6"/>
 <wire x1="299.72" y1="-66.04" x2="279.4" y2="-66.04" width="0.1524" layer="91"/>
 <wire x1="279.4" y1="-66.04" x2="279.4" y2="-91.44" width="0.1524" layer="91"/>
 <wire x1="279.4" y1="-91.44" x2="121.92" y2="-91.44" width="0.1524" layer="91"/>
 <wire x1="121.92" y1="-91.44" x2="121.92" y2="-35.56" width="0.1524" layer="91"/>
 <junction x="121.92" y="-35.56"/>
-<pinref part="U1" gate="G$1" pin="CBUS3"/>
-<wire x1="91.44" y1="38.1" x2="91.44" y2="-35.56" width="0.1524" layer="91"/>
-<wire x1="91.44" y1="-35.56" x2="121.92" y2="-35.56" width="0.1524" layer="91"/>
+<pinref part="JP2" gate="A" pin="5"/>
 </segment>
 </net>
 <net name="N$17" class="0">
@@ -8547,19 +8611,6 @@ Source: www.kingbright.com</description>
 <wire x1="50.8" y1="-33.02" x2="55.88" y2="-33.02" width="0.1524" layer="91"/>
 <pinref part="U3" gate="A" pin="AN12/HLVDIN/SCK1/CTED2/CN14/RB12"/>
 <wire x1="50.8" y1="-63.5" x2="139.7" y2="-63.5" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="N$20" class="0">
-<segment>
-<pinref part="R8" gate="G$1" pin="2"/>
-<pinref part="R9" gate="G$1" pin="1"/>
-<pinref part="C9" gate="G$1" pin="1"/>
-<wire x1="76.2" y1="-33.02" x2="81.28" y2="-33.02" width="0.1524" layer="91"/>
-<junction x="76.2" y="-33.02"/>
-<wire x1="71.12" y1="-60.96" x2="71.12" y2="-33.02" width="0.1524" layer="91"/>
-<wire x1="71.12" y1="-33.02" x2="76.2" y2="-33.02" width="0.1524" layer="91"/>
-<pinref part="U3" gate="A" pin="AN11/SDO1/CTPLS/CN13/RB13"/>
-<wire x1="71.12" y1="-60.96" x2="139.7" y2="-60.96" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="PICTX1" class="0">
@@ -8588,38 +8639,27 @@ Source: www.kingbright.com</description>
 </net>
 <net name="N$8" class="0">
 <segment>
-<pinref part="J2" gate="A" pin="2"/>
 <wire x1="299.72" y1="-55.88" x2="264.16" y2="-55.88" width="0.1524" layer="91"/>
 <wire x1="264.16" y1="-55.88" x2="264.16" y2="-53.34" width="0.1524" layer="91"/>
 <pinref part="U3" gate="A" pin="PGC3/SOSCO/T1CK/*U2CTS/CN0/RA4"/>
 <wire x1="264.16" y1="-53.34" x2="254" y2="-53.34" width="0.1524" layer="91"/>
+<pinref part="JP2" gate="A" pin="1"/>
 </segment>
 </net>
 <net name="N$9" class="0">
 <segment>
-<pinref part="J2" gate="A" pin="3"/>
 <wire x1="299.72" y1="-58.42" x2="264.16" y2="-58.42" width="0.1524" layer="91"/>
 <wire x1="264.16" y1="-58.42" x2="264.16" y2="-63.5" width="0.1524" layer="91"/>
 <pinref part="U3" gate="A" pin="PGD3/SOSCI/*U2RTS/CN1/RB4"/>
 <wire x1="264.16" y1="-63.5" x2="254" y2="-63.5" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="N$12" class="0">
-<segment>
-<pinref part="LED1" gate="G$1" pin="A"/>
-<pinref part="R11" gate="G$1" pin="1"/>
-</segment>
-</net>
-<net name="N$13" class="0">
-<segment>
-<pinref part="LED2" gate="G$1" pin="A"/>
-<pinref part="R12" gate="G$1" pin="1"/>
+<pinref part="JP2" gate="A" pin="2"/>
 </segment>
 </net>
 <net name="CLOCK" class="0">
 <segment>
 <wire x1="256.54" y1="58.42" x2="251.46" y2="58.42" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="CLK"/>
+<pinref part="JP3" gate="G$1" pin="CLK"/>
+<label x="241.3" y="58.42" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="R10" gate="G$1" pin="1"/>
@@ -8636,7 +8676,8 @@ Source: www.kingbright.com</description>
 <net name="DATA" class="0">
 <segment>
 <wire x1="256.54" y1="55.88" x2="251.46" y2="55.88" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="DATA"/>
+<pinref part="JP3" gate="G$1" pin="DATA"/>
+<label x="241.3" y="55.88" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="R5" gate="G$1" pin="1"/>
@@ -8653,7 +8694,8 @@ Source: www.kingbright.com</description>
 <net name="ALARM" class="0">
 <segment>
 <wire x1="256.54" y1="53.34" x2="251.46" y2="53.34" width="0.1524" layer="91"/>
-<pinref part="J3" gate="G$1" pin="ALARM"/>
+<pinref part="JP3" gate="G$1" pin="ALARM"/>
+<label x="241.3" y="53.34" size="1.778" layer="95"/>
 </segment>
 <segment>
 <pinref part="R3" gate="G$1" pin="1"/>
@@ -8665,6 +8707,12 @@ Source: www.kingbright.com</description>
 <pinref part="U3" gate="A" pin="REFO/*SS1/T2CK/T3CK/CN11/RB15"/>
 <wire x1="129.54" y1="-38.1" x2="139.7" y2="-38.1" width="0.1524" layer="91"/>
 <label x="132.08" y="-38.1" size="1.778" layer="95"/>
+</segment>
+</net>
+<net name="N$7" class="0">
+<segment>
+<pinref part="R12" gate="G$1" pin="1"/>
+<pinref part="LED2" gate="G$1" pin="A"/>
 </segment>
 </net>
 </nets>


### PR DESCRIPTION
I updated the MoMo FSU to version 3.0.  This version now has a modular connector with the same pinout as the MoMos to permit easier connection.  It has been resized to fit the Polycase USB-31 case:
http://www.polycase.com/usb-31

The board is finished and ready to go.  The only change from the current version is the removal of an ADC line on the 2.8V power supply of the MoMo.  The ADC line on the 4V supply is still there.  This was removed because it provided no useful information.  If the 4V supply is there, the 2.8V regulator will be producing 2.8V.  The only variable voltage is the battery voltage so that should be measured.
