### PR TITLE
Create a virtual development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ config/*.local.json
 funclist
 *.sconsign.dblite
 config/*.cache*
+
+.vagrant
+.cached_downloads

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise64"
+  config.vm.box_url = "https://vagrantcloud.com/hashicorp/precise64/version/2/provider/virtualbox.box"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ['modifyvm', :id, '--usb', 'on']
+    vb.customize ['usbfilter', 'add', '0', '--target', :id, '--name', 'MoMoFSU', '--vendorid', '0x0403', '--productid', '0x6015']
+  end
+
+  config.vm.network "forwarded_port", guest: 80, host: 1111
+
+  config.vm.provision "shell", path: "tools/vagrant/provision.sh"
+end

--- a/tools/vagrant/provision.sh
+++ b/tools/vagrant/provision.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+die() { echo "$@" 1>&2; exit 1; }
+
 apt-get update
 apt-get install -y python python-setuptools python-dev libc6:i386
 
@@ -25,15 +27,18 @@ elif [ ! -e ./$XC8INSTALLER.run ]; then
 		mkdir -p /vagrant/.cached_downloads
 		cp ./$XC8INSTALLER /vagrant/.cached_downloads
 	else
-		echo "Invalid downloaded file hash, exiting!"
 		rm -f ./$XC8INSTALLER
-		exit 1
+		die "Invalid downloaded file hash, exiting!"
 	fi
 fi
 echo "Installing xc8 compiler..."
 ./$XC8INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc8/v1.30"
+CODE=$?
 echo "PATH=\"\$PATH:/opt/microchip/xc8/v1.30/bin\"" >> /home/vagrant/.profile
 rm -f ./$XC8INSTALLER
+if [ $CODE -ne 0 ]; then
+	die "Failed to install xc8, exiting!"
+fi
 echo "DONE!"
 
 XC16INSTALLER=xc16-v1.21-linux-installer.run
@@ -48,14 +53,17 @@ elif [ ! -e ./$XC16INSTALLER ]; then
 		mkdir -p /vagrant/.cached_downloads
 		cp ./$XC16INSTALLER /vagrant/.cached_downloads
 	else
-		echo "Invalid downloaded file hash, exiting!"
 		rm -f ./$XC16INSTALLER
-		exit 1
+		die "Invalid downloaded file hash, exiting!"
 	fi
 fi
 echo "Installing xc16 compiler..."
 ./$XC16INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc16/v1.21"
+CODE=$?
 rm -f ./$XC16INSTALLER
+if [ $CODE -ne 0 ]; then
+	die "Failed to install xc16, exiting!"
+fi
 echo "PATH=\"\$PATH:/opt/microchip/xc16/v1.21/bin\"" >> /home/vagrant/.profile
 echo "DONE!"
 

--- a/tools/vagrant/provision.sh
+++ b/tools/vagrant/provision.sh
@@ -33,6 +33,7 @@ fi
 echo "Installing xc8 compiler..."
 ./$XC8INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc8/v1.30"
 echo "PATH=\"\$PATH:/opt/microchip/xc8/v1.30/bin\"" >> /home/vagrant/.profile
+rm -f ./$XC8INSTALLER
 echo "DONE!"
 
 XC16INSTALLER=xc16-v1.21-linux-installer.run
@@ -54,6 +55,7 @@ elif [ ! -e ./$XC16INSTALLER ]; then
 fi
 echo "Installing xc16 compiler..."
 ./$XC16INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc16/v1.21"
+rm -f ./$XC16INSTALLER
 echo "PATH=\"\$PATH:/opt/microchip/xc16/v1.21/bin\"" >> /home/vagrant/.profile
 echo "DONE!"
 

--- a/tools/vagrant/provision.sh
+++ b/tools/vagrant/provision.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y python python-setuptools python-dev libc6:i386
+
+easy_install cmdln ZODB3 colorama pyparsing intelhex BeautifulSoup4 Cheetah pyserial pytest
+
+SCONSVERSION=2.3.1
+URL=http://sourceforge.net/projects/scons/files/scons/$SCONSVERSION/scons-$SCONSVERSION.tar.gz/download?use_mirror=hivelocity
+wget $URL -O - | tar -xvzf -
+
+cd scons-$SCONSVERSION
+python setup.py install
+cd ..
+
+XC8INSTALLER='xc8-v1.30-linux.run'
+if [ -e /vagrant/.cached_downloads/$XC8INSTALLER ]; then
+	echo "Found cached xc8 installer!"
+	cp /vagrant/.cached_downloads/$XC8INSTALLER .
+elif [ ! -e ./$XC8INSTALLER.run ]; then
+	URL=http://ww1.microchip.com/downloads/en/DeviceDoc/$XC8INSTALLER.tar
+	wget $URL -O - | tar -xvf -
+	SHA=`openssl sha256 ./$XC8INSTALLER`
+	if [ "$SHA" = "SHA256(./$XC8INSTALLER)= c47c850a23b018bd61b45bc1a87988e0a6f4223667b0761375fbf5f33469164b" ]; then
+		mkdir -p /vagrant/.cached_downloads
+		cp ./$XC8INSTALLER /vagrant/.cached_downloads
+	else
+		echo "Invalid downloaded file hash, exiting!"
+		rm -f ./$XC8INSTALLER
+		exit 1
+	fi
+fi
+echo "Installing xc8 compiler..."
+./$XC8INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc8/v1.30"
+echo "PATH=\"\$PATH:/opt/microchip/xc8/v1.30/bin\"" >> /home/vagrant/.profile
+echo "DONE!"
+
+XC16INSTALLER=xc16-v1.21-linux-installer.run
+if [ -e /vagrant/.cached_downloads/$XC16INSTALLER ]; then
+	echo "Found cached xc16 installer!"
+	cp /vagrant/.cached_downloads/$XC16INSTALLER .
+elif [ ! -e ./$XC16INSTALLER ]; then
+	URL=http://ww1.microchip.com/downloads/en/DeviceDoc/$XC16INSTALLER.tar
+	wget $URL -O - | tar -xvf -
+	SHA=`openssl sha256 ./$XC16INSTALLER`
+	if [ "$SHA" = "SHA256(./$XC16INSTALLER)= 2d9a3736a439ad8842bac24de26bc9956cddf6e965288b8152bec770a4a3f06e" ]; then
+		mkdir -p /vagrant/.cached_downloads
+		cp ./$XC16INSTALLER /vagrant/.cached_downloads
+	else
+		echo "Invalid downloaded file hash, exiting!"
+		rm -f ./$XC16INSTALLER
+		exit 1
+	fi
+fi
+echo "Installing xc16 compiler..."
+./$XC16INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc16/v1.21"
+echo "PATH=\"\$PATH:/opt/microchip/xc16/v1.21/bin\"" >> /home/vagrant/.profile
+echo "DONE!"
+
+echo "Adding MoMo tool bin (/vagrant/tools/bin) to the path..."
+echo "PATH=\"\$PATH:/vagrant/tools/bin\"" >> /home/vagrant/.profile
+echo "DONE!"
+
+echo "Adding user 'vagrant' to the group 'dialout' so it can access USB devices..."
+usermod vagrant -a -G dialout
+echo "DONE!"

--- a/tools/vagrant/provision.sh
+++ b/tools/vagrant/provision.sh
@@ -3,7 +3,7 @@
 die() { echo "$@" 1>&2; exit 1; }
 
 apt-get update
-apt-get install -y python python-setuptools python-dev libc6:i386
+apt-get install -y python python-setuptools python-dev libc6:i386 lib32stdc++6
 
 easy_install cmdln ZODB3 colorama pyparsing intelhex BeautifulSoup4 Cheetah pyserial pytest
 
@@ -14,6 +14,8 @@ wget $URL -O - | tar -xvzf -
 cd scons-$SCONSVERSION
 python setup.py install
 cd ..
+
+gem install rake
 
 XC8INSTALLER='xc8-v1.30-linux.run'
 if [ -e /vagrant/.cached_downloads/$XC8INSTALLER ]; then


### PR DESCRIPTION
All dependancies are automatically download and installed in a self-contained VM. Vagrant is used to manage the virtual machine, tested with Vagrant 1.5.1.

Development setup procedure:
- Clone the depot
- Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
- Install [Vagrant](http://www.vagrantup.com/downloads.html)
- run `vagrant up` from anywhere in the cloned repository. (this will take a while the first time, faster later)
- run `vagrant ssh` to ssh into the virtual machine (On Windows, [do this](http://stackoverflow.com/questions/9885108/ssh-to-vagrant-box-in-windows))
- compile source by executing i.e. `cd /vagrant/momo_modules/gsm_module; mibtool build build/output`  NOTE: /vagrant is a live share with the host machine's root repository directory.  Changes made there are reflected on the guest and vice versa.
- connect an FSU and run i.e. `modtool list` from anywhere in the VM - USB devices matching the FSU's vid and pid are automatically attached to the VM

TODO:
- Install gpsim so the VM can compile and run unit tests.  This shouldn't be difficult.
- Make an easy build alias - like a simple makefile in the vagrant user's home directory.  Ideally you should just be able to say `momo-build gsm_module` from the host machine and everything works.
- Add support for building things in places other than the main root directory (for when we split repos)
- Make initial install faster - right now there's half a gig of downloads for the base VM and xc8/xc16.  This could be prohibitively expensive in low-bandwidth situations.  Note that once you've download the base box and xc installers they are cached for later use.
- Do more cool stuff
