### PR TITLE
Fix a missing checksum validation in pic12 code

### DIFF
--- a/momo_modules/pic12_executive/src/bus.h
+++ b/momo_modules/pic12_executive/src/bus.h
@@ -12,19 +12,6 @@
 #define kReturnStatusOffset 1
 #define kReturnValueOffset 3
 
-//Bus error codes that can be returned
-enum
-{
-	kNoMIBError = 0,
-	kUnsupportedCommand = 1,
-	kWrongParameterType = 2,
-	kParameterTooLong = 3,
-	kChecksumError = 4,
-	kUnknownError = 6,
-	kCallbackError = 7,
-	kSlaveNotAvailable = 255
-};
-
 //Takes 2 bits to store
 //Cannot change.  Referenced by mib_hal.as in pic12 code
 typedef enum

--- a/momo_modules/pic12_executive/src/bus_master.c
+++ b/momo_modules/pic12_executive/src/bus_master.c
@@ -96,7 +96,8 @@ uint8 bus_master_tryrpc()
 		//At this point we know that we read a valid return status, check what it tells us
 
 		//If there was a checksum error on the command packet
-		if (mib_data.return_status.bus_returnstatus.result == kChecksumError)
+		if ( mib_data.return_status.bus_returnstatus.result == kCommandChecksumError
+ 		  || mib_data.return_status.bus_returnstatus.result == kParameterChecksumError )
 			goto restart_command;
 
 		//If there was a return value, read it in

--- a/momo_modules/pic12_executive/src/bus_slave.c
+++ b/momo_modules/pic12_executive/src/bus_slave.c
@@ -28,7 +28,7 @@ static void bus_slave_searchcommand()
 {
 	if (i2c_calculate_checksum() != 0)
 	{
-		bus_slave_setreturn(pack_return_status(kChecksumError, 0)); //Make sure the parameter checksum was valid.
+		bus_slave_setreturn(pack_return_status(kCommandChecksumError, 0)); //Make sure the command checksum was valid.
 		return;
 	}
 
@@ -53,9 +53,15 @@ static void bus_slave_searchcommand()
  */
 static uint8 bus_slave_validateparams()
 {
+	if (i2c_calculate_checksum() != 0)
+	{
+		bus_slave_seterror(kParameterChecksumError); //Make sure the parameter checksum was valid.
+		return 0;
+	}
+	
 	if (!validate_param_spec(mib_state.slave_handler))
 	{
-		bus_slave_setreturn(pack_return_status(kWrongParameterType, 0)); //Make sure the parameter checksum was valid.
+		bus_slave_setreturn(pack_return_status(kWrongParameterType, 0)); //Check the type of the parameter.
 		return 0;
 	}
 

--- a/momo_modules/pic12_executive/src/bus_slave.c
+++ b/momo_modules/pic12_executive/src/bus_slave.c
@@ -55,7 +55,7 @@ static uint8 bus_slave_validateparams()
 {
 	if (i2c_calculate_checksum() != 0)
 	{
-		bus_slave_seterror(kParameterChecksumError); //Make sure the parameter checksum was valid.
+		bus_slave_setreturn(pack_return_status(kParameterChecksumError, 0)); //Make sure the parameter checksum was valid.
 		return 0;
 	}
 	

--- a/momo_modules/pic12_executive/src/bus_slave.h
+++ b/momo_modules/pic12_executive/src/bus_slave.h
@@ -12,4 +12,8 @@ void bus_slave_setreturn(uint8 status);
 uint8 bus_slave_checkparamsize();
 uint8 bus_retval_size();
 
+#define mib_success() bus_slave_setreturn( pack_return_status(0,0) )
+#define mib_return(return_length) bus_slave_setreturn( pack_return_status( 0, return_length ) )
+#define mib_error(code,return_length) bus_slave_setreturn( pack_return_status( code, return_length ) )
+
 #endif

--- a/momo_modules/shared/pic24/src/mib/bus.h
+++ b/momo_modules/shared/pic24/src/mib/bus.h
@@ -6,20 +6,6 @@
 #include "i2c.h"
 #include "protocol.h"
 
-//Bus error codes that can be returned
-enum
-{
-	kNoMIBError = 0,
-	kUnsupportedCommand = 1,
-	kWrongParameterType = 2,
-	kParameterTooLong = 3,
-	kParameterChecksumError = 4,
-	kCommandChecksumError = 5,
-	kUnknownError = 6,
-	kCallbackError = 7,
-	kSlaveNotAvailable = 255
-};
-
 //Takes 2 bits to store
 //Cannot change.  Referenced by mib_hal.as in pic12 code
 typedef enum

--- a/momo_modules/shared/pic24/src/mib/slave/bus_slave.c
+++ b/momo_modules/shared/pic24/src/mib/slave/bus_slave.c
@@ -89,7 +89,7 @@ static uint8 bus_slave_validateparams()
 
 	if (!validate_param_spec(mib_state.slave_handler))
 	{
-		bus_slave_seterror(kWrongParameterType); //Make sure the parameter checksum was valid.
+		bus_slave_seterror(kWrongParameterType); //Check the type of the parameter.
 		return 0;
 	}
 

--- a/momo_modules/shared/pic24/src/mib/slave/bus_slave.h
+++ b/momo_modules/shared/pic24/src/mib/slave/bus_slave.h
@@ -11,4 +11,8 @@ void bus_slave_return_buffer( const void* buff, uint8 length );
 inline void bus_slave_set_returnbuffer_length( uint8 length );
 void bus_slave_setreturn(uint8 status);
 
+#define mib_success() bus_slave_setreturn( pack_return_status(0,0) )
+#define mib_return(return_length) bus_slave_setreturn( pack_return_status( 0, return_length ) )
+#define mib_error(code,return_length) bus_slave_setreturn( pack_return_status( code, return_length ) )
+
 #endif

--- a/momo_modules/shared/portable/core/mib_definitions.h
+++ b/momo_modules/shared/portable/core/mib_definitions.h
@@ -12,6 +12,17 @@
 #include "common_types.h"
 #endif
 
+//Bus error codes that can be returned
+#define kNoMIBError             0
+#define kUnsupportedCommand     1
+#define kWrongParameterType     2
+#define kParameterTooLong       3
+#define kParameterChecksumError 4
+#define kCommandChecksumError   5
+#define kUnknownError           6
+#define kCallbackError          7
+#define kSlaveNotAvailable      255
+
 //Well-Known MIB Addresses
 #define kMIBControllerAddress		8
 #define kMIBUnenumeratedAddress		127


### PR DESCRIPTION
Unless I'm missing some edgecase reason for pic12executive not checking parameter checksums (or retrying commands if the receiving end sends a parameter checksum failure)

Also:
- Move status code definitions to a common location
- Create some handy MIB slave return macros.

We should really de-duplicate the MIB code as much as possible, there's still a lot of duplicated logic that could easily get out-of-sync (as it did here)
