### PR TITLE
Make controller sleep when not doing anything else

### DIFF
--- a/momo_modules/field_service_unit/src/debug/debug.c
+++ b/momo_modules/field_service_unit/src/debug/debug.c
@@ -20,7 +20,7 @@ void debug_init()
 
     register_command_handlers(); //register the serial commands that we respond to.
 
-    taskloop_set_sleep(0); //Can't sleep with the UART
+    taskloop_set_flag(kTaskLoopSleepBit, 0); //Can't sleep with the UART
 
     sendf(DEBUG_UART, "Type was: %d.\r\n", last_reset_type());
     put(DEBUG_UART, ACK);

--- a/momo_modules/mainboard/src/core/mainboard_reset_handler.c
+++ b/momo_modules/mainboard/src/core/mainboard_reset_handler.c
@@ -20,8 +20,8 @@ void handle_all_resets_before(unsigned int type)
 {
     //Add code here that should be called before all other reset code
     disable_unneeded_peripherals();
-    init_memory();
-    enable_memory(1);
+    mem_init();
+    mem_ensure_powered(1);
     configure_interrupts();
     //oscillator_init();
 

--- a/momo_modules/mainboard/src/core/mainboard_reset_handler.c
+++ b/momo_modules/mainboard/src/core/mainboard_reset_handler.c
@@ -20,11 +20,13 @@ void handle_all_resets_before(unsigned int type)
 {
     //Add code here that should be called before all other reset code
     disable_unneeded_peripherals();
-    disable_memory();
+    init_memory();
+    enable_memory(1);
     configure_interrupts();
-    oscillator_init();
+    //oscillator_init();
 
     taskloop_init();
+    taskloop_set_sleep(1);
     scheduler_init();
     
     bus_init(kMIBControllerAddress);

--- a/momo_modules/mainboard/src/core/mainboard_reset_handler.c
+++ b/momo_modules/mainboard/src/core/mainboard_reset_handler.c
@@ -26,7 +26,6 @@ void handle_all_resets_before(unsigned int type)
     //oscillator_init();
 
     taskloop_init();
-    taskloop_set_sleep(1);
     scheduler_init();
     
     bus_init(kMIBControllerAddress);

--- a/momo_modules/mainboard/src/core/mainboard_reset_handler.c
+++ b/momo_modules/mainboard/src/core/mainboard_reset_handler.c
@@ -20,6 +20,7 @@ void handle_all_resets_before(unsigned int type)
 {
     //Add code here that should be called before all other reset code
     disable_unneeded_peripherals();
+    disable_memory();
     configure_interrupts();
     oscillator_init();
 

--- a/momo_modules/mainboard/src/main.c
+++ b/momo_modules/mainboard/src/main.c
@@ -50,7 +50,7 @@
 #pragma config DSBOREN = ON             // Deep Sleep Zero-Power BOR Enable bit (Deep Sleep BOR enabled in Deep Sleep)
 #pragma config DSWDTEN = OFF            // Deep Sleep Watchdog Timer Enable bit (DSWDT disabled)
 
-int sleep_handler(int task);
+TaskManagerSleepStatus sleep_handler(TaskManagerCallbackReason task);
 
 int main(void)
 {
@@ -66,11 +66,11 @@ int main(void)
     return (EXIT_SUCCESS);
 }
 
-int sleep_handler(int task)
+TaskManagerSleepStatus sleep_handler(TaskManagerCallbackReason task)
 {
 	if (bus_master_idle())
 	{
-		disable_memory();
+		mem_remove_power();
 		return kCanEnterSleep;
 	}
 

--- a/momo_modules/mainboard/src/main.c
+++ b/momo_modules/mainboard/src/main.c
@@ -16,7 +16,7 @@
 #pragma config GCP = OFF                // General Segment Code Flash Code Protection bit (No protection)
 
 // FOSCSEL
-#pragma config FNOSC = FRC           	// Oscillator Select (8 MHz FRC oscillator (FRC)) with PLL
+#pragma config FNOSC = FRC           	// Oscillator Select (8 MHz FRC oscillator (FRC)) without PLL
 #pragma config IESO  = OFF              // Internal External Switch Over bit (Internal External Switchover mode disabled (Two-Speed Start-up disabled))
 
 // FOSC
@@ -56,10 +56,6 @@ ScheduledTask i2c;
 int main(void)
 {
     AD1PCFG = 0xFFFF;
-
-    //Enable the Memory Module
-    _RB7 = 1;
-    _TRISB7 = 0;
 
     register_reset_handlers();
     handle_reset();

--- a/momo_modules/mainboard/src/main.c
+++ b/momo_modules/mainboard/src/main.c
@@ -3,6 +3,7 @@
 #include "mainboard_reset_handler.h"
 #include "task_manager.h"
 #include "scheduler.h"
+#include "memory.h"
 #include "bus_master.h"
 #include "report_manager.h"
 #include <string.h>
@@ -49,9 +50,7 @@
 #pragma config DSBOREN = ON             // Deep Sleep Zero-Power BOR Enable bit (Deep Sleep BOR enabled in Deep Sleep)
 #pragma config DSWDTEN = OFF            // Deep Sleep Watchdog Timer Enable bit (DSWDT disabled)
 
-ScheduledTask task1;
-
-ScheduledTask i2c;
+int sleep_handler(int task);
 
 int main(void)
 {
@@ -59,8 +58,21 @@ int main(void)
 
     register_reset_handlers();
     handle_reset();
+
+    taskloop_set_sleephandler(sleep_handler);
     
     taskloop_loop();
 
     return (EXIT_SUCCESS);
+}
+
+int sleep_handler(int task)
+{
+	if (bus_master_idle())
+	{
+		disable_memory();
+		return kCanEnterSleep;
+	}
+
+	return kCannotEnterSleep;
 }

--- a/momo_modules/mainboard/src/mib/controller_mib_feature.c
+++ b/momo_modules/mainboard/src/mib/controller_mib_feature.c
@@ -165,6 +165,13 @@ void debug_value()
 	bus_slave_return_int16(debug_flag_value);
 }
 
+void set_sleep()
+{
+	if (plist_get_int16(0))
+		taskloop_set_sleep(1);
+	else
+		taskloop_set_sleep(0);
+}
 
 
 DEFINE_MIB_FEATURE_COMMANDS(controller) {
@@ -182,5 +189,6 @@ DEFINE_MIB_FEATURE_COMMANDS(controller) {
 	{0x0B, report_battery, plist_spec_empty()},
 	{0x0C, current_time, plist_spec_empty()},
 	{0x0D, debug_value, plist_spec_empty()},
+	{0x0E, set_sleep, plist_spec(1, false)}
 };
 DEFINE_MIB_FEATURE(controller);

--- a/momo_modules/mainboard/src/mib/controller_mib_feature.c
+++ b/momo_modules/mainboard/src/mib/controller_mib_feature.c
@@ -25,6 +25,8 @@ void con_init()
 	BUS_ENABLE_TRIS = 1;
 	BUS_ENABLE_DIG = 1;
 	BUS_ENABLE_LAT = 1;
+
+	con_reset_bus();
 }
 
 void con_reset_bus()

--- a/momo_modules/mainboard/src/mib/controller_mib_feature.c
+++ b/momo_modules/mainboard/src/mib/controller_mib_feature.c
@@ -168,9 +168,9 @@ void debug_value()
 void set_sleep()
 {
 	if (plist_get_int16(0))
-		taskloop_set_sleep(1);
+		taskloop_set_flag(kTaskLoopSleepBit, 1);
 	else
-		taskloop_set_sleep(0);
+		taskloop_set_flag(kTaskLoopSleepBit, 0);
 }
 
 

--- a/momo_modules/mainboard/src/momo/memory_manager.c
+++ b/momo_modules/mainboard/src/momo/memory_manager.c
@@ -20,8 +20,6 @@ static inline memory_block create_block( unsigned int subsection_index, unsigned
 
 void flash_memory_init()
 {
-  configure_SPI();
-
   init_momo_config(kMomoConfigSubsector); // Currently accepts a subsection index, not an address
 
   memory_block log_memory_block = create_block(MEMORY_SECTION_TO_SUB(kSensorDataSector), kSensorLogSubsectors);

--- a/momo_modules/shared/pic24/src/core/task_manager.c
+++ b/momo_modules/shared/pic24/src/core/task_manager.c
@@ -3,6 +3,7 @@
 #include "uart.h"
 #include "utilities.h"
 #include "pic24.h"
+#include "memory.h"
 
 task_list taskqueue;
 void taskloop_init()
@@ -10,7 +11,7 @@ void taskloop_init()
     ringbuffer_create(&taskqueue.tasks, (void*)taskqueue.taskdata, sizeof(task_item), kMAXTASKS);
     taskqueue.flags = 0;
 
-    taskloop_set_sleep(0);
+    taskloop_set_sleep(1);
 }
 
 void taskloop_set_sleep(int sleep)
@@ -65,8 +66,10 @@ void taskloop_loop()
             ;
 
         if ( BIT_TEST(taskqueue.flags, kTaskLoopSleepBit) )
+        {
+            disable_memory();
             asm_sleep();
-
+        }
     }
 }
 int taskloop_process_one()

--- a/momo_modules/shared/pic24/src/core/task_manager.c
+++ b/momo_modules/shared/pic24/src/core/task_manager.c
@@ -11,16 +11,33 @@ void taskloop_init()
 {
     ringbuffer_create(&taskqueue.tasks, (void*)taskqueue.taskdata, sizeof(task_item), kMAXTASKS);
     taskqueue.flags = 0;
+    taskqueue.sleep_handler = NULL;
 
-    taskloop_set_sleep(0);
+    taskloop_set_flag(kTaskLoopSleepBit, 0);
 }
 
-void taskloop_set_sleep(int sleep)
+void taskloop_set_flag(unsigned int flag, unsigned int value)
 {
-    if (sleep)
-        SET_BIT(taskqueue.flags, kTaskLoopSleepBit);
+    if (flag >= 16)
+        return;
+
+    if (value)
+        SET_BIT(taskqueue.flags, flag);
     else
-        CLEAR_BIT(taskqueue.flags, kTaskLoopSleepBit);
+        CLEAR_BIT(taskqueue.flags, flag);
+}
+
+int taskloop_get_flag(unsigned int flag)
+{
+    if (flag >= 16)
+        return 0;
+
+    return BIT_TEST(taskqueue.flags, flag);
+}
+
+void taskloop_set_sleephandler(sleep_callback handler)
+{
+    taskqueue.sleep_handler = handler;
 }
 
 int taskloop_add_impl(task_callback task, bool critical )
@@ -63,17 +80,13 @@ void taskloop_loop()
 {
     while(1)
     {
-        while( taskloop_process_one() )
+        while (taskloop_process_one())
             ;
 
-        if ( BIT_TEST(taskqueue.flags, kTaskLoopSleepBit) )
+        if (BIT_TEST(taskqueue.flags, kTaskLoopSleepBit))
         {
-            //Don't cut-off an rpc master call in progress.
-            if (bus_master_idle())
-            {
-                disable_memory();
+            if (taskqueue.sleep_handler == NULL || taskqueue.sleep_handler(kSleepCallback) == kCanEnterSleep)
                 asm_sleep();
-            }
         }
     }
 }

--- a/momo_modules/shared/pic24/src/core/task_manager.h
+++ b/momo_modules/shared/pic24/src/core/task_manager.h
@@ -14,23 +14,28 @@
 
 #define kMAXTASKS 16 //NB Must be a power of 2 since it will be used for a ringbuffer
 
-typedef void (*task_callback)(void);
-typedef int (*sleep_callback)(int);
-
-enum
+typedef enum
 {
     kTaskLoopSleepBit = 0,
     kTaskLoopLockedBit = 1,
     kTaskLoopDisableMemoryBit = 2
-};
+} TaskManagerFlag;
 
-enum
+typedef enum
 {
-	kCanEnterSleep = 0,
-	kCannotEnterSleep,
 	kSleepCallback,
 	kWakeupCallback
-};
+} TaskManagerCallbackReason;
+
+typedef enum
+{
+    kCanEnterSleep = 0,
+    kCannotEnterSleep
+} TaskManagerSleepStatus;
+
+//Callback Types
+typedef void (*task_callback)(void);
+typedef TaskManagerSleepStatus (*sleep_callback)(TaskManagerCallbackReason);
 
 typedef struct
 {
@@ -40,19 +45,19 @@ typedef struct
 
 typedef struct
 {
-    task_item 		taskdata[kMAXTASKS];
-    ringbuffer 		tasks;
+    task_item       taskdata[kMAXTASKS];
+    ringbuffer      tasks;
     sleep_callback 	sleep_handler;
 
-    unsigned int flags;
+    unsigned int    flags;
 } task_list;
 
 //functions
 void taskloop_init();
 
 
-void taskloop_set_flag(unsigned int flag, unsigned int value);
-int taskloop_get_flag(unsigned int flag);
+void taskloop_set_flag(TaskManagerFlag flag, unsigned int value);
+int taskloop_get_flag(TaskManagerFlag flag);
 
 void taskloop_set_sleephandler(sleep_callback handler);
 

--- a/momo_modules/shared/pic24/src/core/task_manager.h
+++ b/momo_modules/shared/pic24/src/core/task_manager.h
@@ -15,11 +15,21 @@
 #define kMAXTASKS 16 //NB Must be a power of 2 since it will be used for a ringbuffer
 
 typedef void (*task_callback)(void);
+typedef int (*sleep_callback)(int);
 
 enum
 {
     kTaskLoopSleepBit = 0,
-    kTaskLoopLockedBit = 1
+    kTaskLoopLockedBit = 1,
+    kTaskLoopDisableMemoryBit = 2
+};
+
+enum
+{
+	kCanEnterSleep = 0,
+	kCannotEnterSleep,
+	kSleepCallback,
+	kWakeupCallback
 };
 
 typedef struct
@@ -30,8 +40,9 @@ typedef struct
 
 typedef struct
 {
-    task_item taskdata[kMAXTASKS];
-    ringbuffer tasks;
+    task_item 		taskdata[kMAXTASKS];
+    ringbuffer 		tasks;
+    sleep_callback 	sleep_handler;
 
     unsigned int flags;
 } task_list;
@@ -39,7 +50,11 @@ typedef struct
 //functions
 void taskloop_init();
 
-void taskloop_set_sleep(int sleep);
+
+void taskloop_set_flag(unsigned int flag, unsigned int value);
+int taskloop_get_flag(unsigned int flag);
+
+void taskloop_set_sleephandler(sleep_callback handler);
 
 int taskloop_add(task_callback task);
 int taskloop_add_critical(task_callback task);

--- a/momo_modules/shared/pic24/src/mib/master/bus_master.c
+++ b/momo_modules/shared/pic24/src/mib/master/bus_master.c
@@ -12,6 +12,11 @@ void 			bus_master_rpc_async_do();
 
 const rpc_info *master_rpcdata;
 
+unsigned int bus_master_idle()
+{
+	return mib_state.rpc_done;
+}
+
 static void bus_master_finish()
 {
 	unsigned int i=0;

--- a/momo_modules/shared/pic24/src/mib/master/bus_master.h
+++ b/momo_modules/shared/pic24/src/mib/master/bus_master.h
@@ -7,4 +7,5 @@
 void bus_master_callback();
 void bus_master_rpc_async(mib_rpc_function callback, MIBUnified *data);
 void bus_master_init();
+unsigned int bus_master_idle();
 #endif

--- a/momo_modules/shared/pic24/src/modules/memory.c
+++ b/momo_modules/shared/pic24/src/modules/memory.c
@@ -211,7 +211,6 @@ void mem_write_aligned(const uint32 addr, const BYTE *data, unsigned int length)
 
   enable_memory(1);
 
-  mem_wait_while_writing();
   mem_enable_write();
   ENABLE_MEMORY();
   PAGE_PROGRAM_MODE();
@@ -222,6 +221,8 @@ void mem_write_aligned(const uint32 addr, const BYTE *data, unsigned int length)
     spi_transfer(data[i]);
 
   DISABLE_MEMORY();
+
+  mem_wait_while_writing();
 }
 
 void mem_read(uint32 addr, BYTE* buf, unsigned int numBytes) 
@@ -258,8 +259,6 @@ BYTE mem_status()
 void mem_clear_all() 
 {
   enable_memory(1);
-
-  mem_wait_while_writing();
   mem_enable_write();
 
   ENABLE_MEMORY();
@@ -272,8 +271,6 @@ void mem_clear_all()
 void mem_clear_subsection(uint32 addr) 
 {
   enable_memory(1);
-
-  mem_wait_while_writing();
   mem_enable_write();
 
   ENABLE_MEMORY();

--- a/momo_modules/shared/pic24/src/modules/memory.h
+++ b/momo_modules/shared/pic24/src/modules/memory.h
@@ -27,10 +27,9 @@ typedef struct
 	unsigned int reserved : 14;
 } memory_config;
 
-void configure_SPI();
-
 void mem_write(uint32 addr, const BYTE* data, unsigned int length );
 void mem_write_aligned(const uint32 addr, const BYTE* data, unsigned int length);
+void mem_wait_while_writing();
 void mem_read(uint32 addr, BYTE* buf, unsigned int numBytes );
 
 void mem_clear_subsection(uint32 addr);
@@ -40,6 +39,8 @@ BYTE mem_status();
 bool mem_test();
 
 void disable_memory();
-void enable_memory();
+void enable_memory(uint8 for_writing);
+void init_memory();
+unsigned int memory_enabled();
 
 #endif

--- a/momo_modules/shared/pic24/src/modules/memory.h
+++ b/momo_modules/shared/pic24/src/modules/memory.h
@@ -27,9 +27,14 @@ typedef struct
 	unsigned int reserved : 14;
 } memory_config;
 
+typedef enum
+{
+	kReadOnly = 0,
+	kReadWrite = 1
+} MemoryStartupTimer;
+
 void mem_write(uint32 addr, const BYTE* data, unsigned int length );
 void mem_write_aligned(const uint32 addr, const BYTE* data, unsigned int length);
-void mem_wait_while_writing();
 void mem_read(uint32 addr, BYTE* buf, unsigned int numBytes );
 
 void mem_clear_subsection(uint32 addr);
@@ -38,9 +43,9 @@ void mem_clear_all();
 BYTE mem_status();
 bool mem_test();
 
-void disable_memory();
-void enable_memory(uint8 for_writing);
-void init_memory();
-unsigned int memory_enabled();
+void mem_remove_power();
+void mem_ensure_powered(MemoryStartupTimer for_writing);
+void mem_init();
+unsigned int mem_enabled();
 
 #endif

--- a/momo_modules/shared/pic24/src/modules/memory.h
+++ b/momo_modules/shared/pic24/src/modules/memory.h
@@ -17,6 +17,13 @@
 #define MEMORY_ADDRESS_MASK 0xFFFFFL
 #define MEMORY_CAPACITY			0x14		//defined in M25PX_80 datasheet (page 21)
 
+typedef struct
+{
+	unsigned int write_wait : 1;
+	unsigned int enabled : 1;
+	unsigned int reserved : 14;
+} memory_status;
+
 void configure_SPI();
 
 void mem_write(uint32 addr, const BYTE* data, unsigned int length );
@@ -28,3 +35,6 @@ void mem_clear_all();
 
 BYTE mem_status();
 bool mem_test();
+
+void disable_memory();
+void enable_memory();

--- a/momo_modules/shared/pic24/src/modules/memory.h
+++ b/momo_modules/shared/pic24/src/modules/memory.h
@@ -1,3 +1,6 @@
+#ifndef __memory_h__
+#define __memory_h__
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "pic24.h"
@@ -22,7 +25,7 @@ typedef struct
 	unsigned int write_wait : 1;
 	unsigned int enabled : 1;
 	unsigned int reserved : 14;
-} memory_status;
+} memory_config;
 
 void configure_SPI();
 
@@ -38,3 +41,5 @@ bool mem_test();
 
 void disable_memory();
 void enable_memory();
+
+#endif

--- a/momo_modules/shared/pic24/test/test_rpc_queue.c
+++ b/momo_modules/shared/pic24/test/test_rpc_queue.c
@@ -9,6 +9,11 @@ void asm_sleep()
 	// do nothing
 }
 
+void disable_memory()
+{
+	
+}
+
 static int task_count = 0;
 void setUp(void) {
 	rpc_queue_init();

--- a/momo_modules/shared/pic24/test/test_rpc_queue.c
+++ b/momo_modules/shared/pic24/test/test_rpc_queue.c
@@ -4,6 +4,7 @@
 #include "ringbuffer.h"
 #include <string.h>
 
+//Mocked functions
 void asm_sleep()
 {
 	// do nothing
@@ -11,7 +12,22 @@ void asm_sleep()
 
 void disable_memory()
 {
-	
+
+}
+
+void mem_wait_while_writing()
+{
+
+}
+
+unsigned int bus_master_idle()
+{
+	return 1;
+}
+
+unsigned int memory_enabled()
+{
+	return 0;
 }
 
 static int task_count = 0;

--- a/tools/pymomo/commander/commands/rpc.py
+++ b/tools/pymomo/commander/commands/rpc.py
@@ -139,7 +139,7 @@ class RPCCommand (Command):
 			elif self.status == 6:
 				parsed['error'] = 'Unknown Error'
 			elif self.status == 7:
-				parsed['error'] = 'Callback Error' % self.result
+				parsed['error'] = 'Callback Error: %s' % str(self.result)
 			else:
 				parsed['error'] = 'Unrecognized MIB status code'
 			return parsed

--- a/tools/pymomo/commander/proxy/controller.py
+++ b/tools/pymomo/commander/proxy/controller.py
@@ -100,6 +100,13 @@ class MIBController (proxy.MIBProxyObject):
 		flag = res['ints'][0]
 		return flag
 
+	def set_sleep(self, val):
+		if val:
+			arg = 1
+		else:
+			arg = 0
+
+		res = self.rpc(42, 0x0E, arg)
 
 	def current_time(self):
 		"""

--- a/tools/pymomo/commander/proxy/controller.py
+++ b/tools/pymomo/commander/proxy/controller.py
@@ -101,12 +101,12 @@ class MIBController (proxy.MIBProxyObject):
 		return flag
 
 	def set_sleep(self, val):
-		if val:
-			arg = 1
-		else:
-			arg = 0
-
-		res = self.rpc(42, 0x0E, arg)
+		"""
+		Enable or disable sleeping on the controller when there are no tasks 
+		to perform.  val should be True to enable sleeping, False to disable 
+		it. 
+		"""
+		res = self.rpc(42, 0x0E, int(bool(val)))
 
 	def current_time(self):
 		"""


### PR DESCRIPTION
Controller now sleeps when the following two conditions are met:
- no tasks in the taskloop
- no rpc master call currently in progress

The flash memory is disabled in sleep to save power.  It is automatically reenabled upon first use by the memory module and there is a wait-state incorporated before the first write to the flash since it needs at least 10 ms to warm up and allow writing.  All flash memory writes now wait until they complete before returning so that we cannot sleep (and disable the memory) while the flash memory was programming itself.

Also made the controller reset the MIB bus whenever it resets so that all modules reregister themselves. This means the controller will always have a correct picture of which modules are on the bus.

Closes #49, #22
