### PR TITLE
Have pcbtool return smd pin and pad counts for assembly

### DIFF
--- a/tools/bin/pcbtool.py
+++ b/tools/bin/pcbtool.py
@@ -137,10 +137,13 @@ class PCBTool(cmdln.Cmdln):
 			lines = len (brd.variants[var])
 			items = sum([len(x) for x in brd.variants[var]])
 
-			print "%s" % var
+			print "Variant Name: %s" % var
 			print "Distinct BOM Lines: %d" % lines
 			print "Total Part Count: %d" % items
-
+			print "Through-Hole Parts: %d" % sum([len(x) for x in brd.variants[var] if x[0].package_info()['pins']>0])
+			print "Total Through-Hole Pins: %d" % sum(map(lambda x: x[0].package_info()['pins']*len(x), brd.variants[var])) 
+			print "SMD Parts: %d" % sum([len(x) for x in brd.variants[var] if x[0].package_info()['pads']>0])
+			print "Total SMD Pads: %d" % sum(map(lambda x: x[0].package_info()['pads']*len(x), brd.variants[var]))
 			print ""
 
 	@cmdln.option('-e', '--excess', action='store', type=float, default=0.0, help="Excess percentage to purchase of each component, in %. (rounded up)")
@@ -150,7 +153,7 @@ class PCBTool(cmdln.Cmdln):
 		order should be specified by giving 3 items:
 		<board id> <variant> <number>
 
-		All baords will have the same excess applied.
+		All boards will have the same excess applied.
 
 		${cmd_usage}
         ${cmd_option_list}

--- a/tools/pymomo/pybom/board.py
+++ b/tools/pymomo/pybom/board.py
@@ -294,7 +294,6 @@ class Board:
 
 		#Find all of the defined packages in this file
 		packages = {x.name: x for x in map(lambda x: Package(x), root.findall('.//package'))}
-		print packages
 
 		elems = root.find("./drawing/board/elements")
 		if elems is None:

--- a/tools/pymomo/pybom/board.py
+++ b/tools/pymomo/pybom/board.py
@@ -8,6 +8,7 @@ from datetime import date
 from octopart.identifier import PartIdentifier
 from octopart.octopart import Octopart
 from reference import PCBReferenceLibrary
+from package import Package
 
 class Board:
 	def __init__(self, name, file, variants, partname, width, height, revision, unknown, nopop):
@@ -191,7 +192,8 @@ class Board:
 			ldict['distpn'] = distpn
 			ldict['unitprice'] = unitprice
 			ldict['lineprice'] = lineprice 
-
+			ldict['pkg_info'] = line[0].pkg_info
+			
 			res['lines'].append(ldict)
 
 		return res
@@ -290,6 +292,10 @@ class Board:
 
 		root = tree.getroot()
 
+		#Find all of the defined packages in this file
+		packages = {x.name: x for x in map(lambda x: Package(x), root.findall('.//package'))}
+		print packages
+
 		elems = root.find("./drawing/board/elements")
 		if elems is None:
 			raise ValueError("File %s does not contain a list of elements.  This is an invalid board file" % brd_file)
@@ -312,7 +318,7 @@ class Board:
 			nopop_vars = set()
 
 			for v in variants:
-				p,found = Part.FromBoardElement(part, v)
+				p,found = Part.FromBoardElement(part, v, packages)
 				if p and found:
 					variable.append( (v, p) )
 					found_vars.add(v)
@@ -324,7 +330,7 @@ class Board:
 					nopop.append(part.get('name',"Unknown Name"))
 
 			#See if this is a constant part (with no changes in different variants)
-			p,found = Part.FromBoardElement(part, "")
+			p,found = Part.FromBoardElement(part, "", packages)
 			if p and len(found_vars) == 0 and len(nopop_vars) == 0:
 				constant.append(p)
 				valid_part = True

--- a/tools/pymomo/pybom/package.py
+++ b/tools/pymomo/pybom/package.py
@@ -1,0 +1,18 @@
+
+class Package:
+	"""
+	A pcb component package containing the number of pads and pins in the package
+	as well as its name.
+	"""
+
+	def __init__(self, element):
+		if element.tag != 'package':
+			raise TypeError('You must pass an ElementTree element to Package.__init__')
+
+		self.name = element.get('name', default="Unknown Name")
+
+		pads = element.findall('./smd')
+		self.num_pads = len(pads)
+
+		pins = element.findall('./pad')
+		self.num_pins = len(pins)

--- a/tools/pymomo/pybom/part.py
+++ b/tools/pymomo/pybom/part.py
@@ -41,7 +41,6 @@ class Part:
 		pkg_info = None
 
 		if pkg in packages:
-			print pkg
 			pkg_info = packages[pkg]
 
 		name = elem.get('name', 'Unnamed')

--- a/tools/pymomo/pybom/part.py
+++ b/tools/pymomo/pybom/part.py
@@ -26,7 +26,7 @@ class Part:
 	ref = reference.PCBReferenceLibrary()
 
 	@staticmethod
-	def FromBoardElement(elem, variant):
+	def FromBoardElement(elem, variant, packages):
 		"""
 		Create a Part object from an element in an EAGLE board file. 
 		pn_attrib specifies the attribute name that contains the correct
@@ -38,6 +38,12 @@ class Part:
 		"""
 
 		pkg = elem.get('package', 'Unknown Package')
+		pkg_info = None
+
+		if pkg in packages:
+			print pkg
+			pkg_info = packages[pkg]
+
 		name = elem.get('name', 'Unnamed')
 		value = elem.get('value', 'No Value')
 
@@ -59,13 +65,13 @@ class Part:
 		digipn = find_digipn(elem, variant)
 
 		if (mpn is not None and manu is not None) or (digipn is not None and digipn != ""):
-			return Part(name, pkg, digipn=digipn, mpn=mpn, manu=manu, value=value, desc=desc), True
+			return Part(name, pkg, digipn=digipn, mpn=mpn, manu=manu, value=value, desc=desc, pkg_info=pkg_info), True
 		elif mpn == "" or digipn == "":
 			return None, True
 
 		return None, False
 
-	def __init__(self, name, package, mpn=None, manu=None, digipn=None, value=None, desc=None):
+	def __init__(self, name, package, mpn=None, manu=None, digipn=None, value=None, desc=None, pkg_info=None):
 		"""
 		Create a part object from the data passed
 		"""
@@ -77,6 +83,7 @@ class Part:
 		self.value = value
 		self.digipn = digipn
 		self.desc = desc
+		self.pkg_info = pkg_info
 
 		#If no description is given try creating a generic one based on the type of the part (resistor, etc)
 		if self.desc is None:
@@ -100,6 +107,12 @@ class Part:
 			return "%s_%s" % (self.manu, self.mpn)
 
 		return "Digikey_%s" % self.digipn
+
+	def package_info(self):
+		if self.pkg_info is None:
+			return {'pins': 0, 'pads': 0}
+
+		return {'pins': self.pkg_info.num_pins, 'pads': self.pkg_info.num_pads}
 
 def attrib_name(name, variant):
 	if variant == "MAIN" or variant == "":


### PR DESCRIPTION
Running:

```
pcbtool info -v <VARIANT>
```

will now calculate and show the total number of through-hole pins, smd pads, part count and distinct part count since these are the relevant quantities for quoting pcb assembly.
