### PR TITLE
Fix mibtool to allow for parallel builds

### DIFF
--- a/tools/bin/mibtool
+++ b/tools/bin/mibtool
@@ -1,2 +1,6 @@
 #!/usr/bin/env python
 import mibtool
+import sys
+
+mt = mibtool.MIBTool()
+sys.exit(mt.main())

--- a/tools/bin/mibtool.py
+++ b/tools/bin/mibtool.py
@@ -248,5 +248,6 @@ class MIBTool(cmdln.Cmdln):
 		print Fore.RED + "Error Occurred: " + Style.RESET_ALL + text
 		sys.exit(1)
 
-mibtool = MIBTool()
-sys.exit(mibtool.main())
+if __name__ == "__main__":
+	mibtool = MIBTool()
+	sys.exit(mibtool.main())


### PR DESCRIPTION
For some reason on linux, invoking -j5 on mibtool (not mibtool.py)
caused the program to hang and need to be -9 killed.  Traced the
problem to running mibtool.py via an import mibtool call.

Replaced it by importing the MIBTool class and running it directly.

Tested and works on windows 7, gentoo linux and Mac OS X Mavericks.  Should work on everything.
