### PR TITLE
Reporting hang bug

### DIFF
--- a/momo_modules/mainboard/src/mib/scheduler_mib_feature.c
+++ b/momo_modules/mainboard/src/mib/scheduler_mib_feature.c
@@ -5,130 +5,130 @@
 #include "scheduler.h"
 #include "common_types.h"
 #include "bus_master.h"
+#include "system_log.h"
 
 typedef struct {
-	uint8 address;
-	uint8 feature;
-	uint8 command;
+    uint8 address;
+    uint8 feature;
+    uint8 command;
 
-	AlarmRepeatTime frequency;
+    AlarmRepeatTime frequency;
 
-	ScheduledTask task;
-	uint8 rpc_id;
+    ScheduledTask task;
+    uint8 flags;
 } RPCCallback;
-
-static uint8 current_rpc_id = 1;
-
 
 #define MAX_SCHEDULED_CALLBACKS 16
 static RPCCallback callbacks[MAX_SCHEDULED_CALLBACKS];
 
 static void rpc_done( uint8 status )
 {
-	uint8 index;
-	for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
-	{
-		if ( callbacks[index].rpc_id == current_rpc_id )
-		{
-			callbacks[index].rpc_id = 0;
-			break;
-		}
-	}
+    uint8 index;
+    for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
+    {
+        if (BIT(callbacks[index].flags, kRPCInProgress))
+        {
+            CLEAR_BIT(callbacks[index].flags, kRPCInProgress);
+            return;
+        }
+    }
 }
 static void callback( void* arg )
 {
-	RPCCallback *cb = (RPCCallback*) arg;
+    RPCCallback *cb = (RPCCallback*) arg;
 
-	if ( cb->rpc_id > current_rpc_id )
-		return;
+    if (BIT(cb->flags, kRPCInProgress))
+        return;
 
-	cb->rpc_id = (current_rpc_id++);
-	if ( current_rpc_id == 0 )
-		current_rpc_id = 1;
+    //CRITICAL_LOGL("Scheduling periodic RPC call.");
 
-	MIBUnified cmd;
-	cmd.address = cb->address;
-  cmd.bus_command.feature = cb->feature;
-  cmd.bus_command.command = cb->command;
-  cmd.bus_command.param_spec = plist_empty();
-	bus_master_rpc_async( rpc_done, &cmd );
+    MIBUnified cmd;
+    cmd.address = cb->address;
+    cmd.bus_command.feature = cb->feature;
+    cmd.bus_command.command = cb->command;
+    cmd.bus_command.param_spec = plist_empty();
+
+    SET_BIT(cb->flags, kRPCInProgress);
+    bus_master_rpc_async( rpc_done, &cmd );
 }
 
 void schedule_callback()
 {
-	uint8 address = plist_get_int16(0) & 0xFF;
-	uint8 feature = plist_get_int16(1) >> 8;
-	uint8 command = plist_get_int16(1) & 0xFF;
-	uint8 frequency = plist_get_int16(2) & 0xFF;
+    uint8 address = plist_get_int16(0) & 0xFF;
+    uint8 feature = plist_get_int16(1) >> 8;
+    uint8 command = plist_get_int16(1) & 0xFF;
+    uint8 frequency = plist_get_int16(2) & 0xFF;
 
-	uint8 index = 0;
-	for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
-	{
-		if ( callbacks[index].address == 0 )
-		{
-			RPCCallback* cb = &(callbacks[index]);
-			cb->address = address;
-			cb->feature = feature;
-			cb->command = command;
-			cb->frequency = frequency;
-			cb->rpc_id = 0;
+    uint8 index = 0;
+    for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
+    {
+        if ( callbacks[index].address == 0 )
+        {
+            RPCCallback* cb = &(callbacks[index]);
+            cb->address = address;
+            cb->feature = feature;
+            cb->command = command;
+            cb->frequency = frequency;
+            cb->flags = 0;
+            cb->task.flags = 0; //Make sure we zero out flags so that the scheduler knows that this isn't an already scheduled task
 
-			scheduler_schedule_task( callback, cb->frequency, kScheduleForever, &(cb->task), (void*) cb );
-			break;
-		}
-	}
-	if ( index == 16 )
-		bus_slave_seterror(kCallbackError);
+            scheduler_schedule_task( callback, cb->frequency, kScheduleForever, &(cb->task), (void*) cb );
+            break;
+        }
+    }
+    if ( index == 16 )
+        bus_slave_seterror(kCallbackError);
 }
 
 void stop_scheduled_callback()
 {
-	uint8 address = plist_get_int16(0) & 0xFF;
-	uint8 feature = plist_get_int16(1) >> 8;
-	uint8 command = plist_get_int16(1) & 0xFF;
-	uint8 frequency = plist_get_int16(2) & 0xFF;
+    uint8 address = plist_get_int16(0) & 0xFF;
+    uint8 feature = plist_get_int16(1) >> 8;
+    uint8 command = plist_get_int16(1) & 0xFF;
+    uint8 frequency = plist_get_int16(2) & 0xFF;
 
-	uint8 index;
-	for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
-	{
-		if ( callbacks[index].address == address &&
-			   callbacks[index].feature == feature &&
-			   callbacks[index].command == command &&
-			   callbacks[index].frequency == frequency )
-		{
-			scheduler_remove_task( &callbacks[index].task );
-			callbacks[index].address = 0;
-		}
-	}
+    uint8 index;
+    for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
+    {
+        if ( callbacks[index].address == address &&
+               callbacks[index].feature == feature &&
+               callbacks[index].command == command &&
+               callbacks[index].frequency == frequency )
+        {
+            scheduler_remove_task( &callbacks[index].task );
+            callbacks[index].address = 0;
+        }
+    }
 }
 
 void get_callback_map()
 {
-	uint32 callback_map = 0;
-	uint8 index;
-	for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
-	{
-		if ( callbacks[index].address != 0 )
-			callback_map |= 0x1 << index;
-	}
-	bus_slave_return_int16( callback_map );
+    uint16 callback_map = 0;
+
+    uint8 index;
+    for ( index = 0; index < MAX_SCHEDULED_CALLBACKS; ++index )
+    {
+        if ( callbacks[index].address != 0 )
+            callback_map |= 0x1 << index;
+    }
+    bus_slave_return_int16( callback_map );
 }
 
 void describe_callback()
 {
-	uint8 index = plist_get_int8(0);
-	if ( index >= MAX_SCHEDULED_CALLBACKS || callbacks[index].address == 0 )
-	{
-		bus_slave_seterror( kCallbackError );
-		return;
-	}
-	bus_slave_return_buffer( &(callbacks[index]), sizeof(RPCCallback) );
+    uint8 index = plist_get_int8(0);
+    if ( index >= MAX_SCHEDULED_CALLBACKS || callbacks[index].address == 0 )
+    {
+        bus_slave_seterror( kCallbackError );
+        return;
+    }
+    bus_slave_return_buffer( &(callbacks[index]), sizeof(RPCCallback) );
 }
 
 DEFINE_MIB_FEATURE_COMMANDS(scheduler) {
-	{0x00, schedule_callback, plist_spec(3,false) },
-	{0x01, stop_scheduled_callback, plist_spec(3,false) },
-	{0x02, get_callback_map, plist_spec(0,false) },
-	{0x03, describe_callback, plist_spec(1,false) }
+    {0x00, schedule_callback, plist_spec(3,false) },
+    {0x01, stop_scheduled_callback, plist_spec(3,false) },
+    {0x02, get_callback_map, plist_spec(0,false) },
+    {0x03, describe_callback, plist_spec(1,false) }
 };
 DEFINE_MIB_FEATURE(scheduler);

--- a/momo_modules/mainboard/src/mib/scheduler_mib_feature.h
+++ b/momo_modules/mainboard/src/mib/scheduler_mib_feature.h
@@ -1,4 +1,6 @@
 #ifndef __scheduler_mib_feature_h
 #define __scheduler_mib_feature_h
 
+#define kRPCInProgress	0
+
 #endif

--- a/momo_modules/mainboard/src/momo/report_manager.c
+++ b/momo_modules/mainboard/src/momo/report_manager.c
@@ -300,6 +300,7 @@ void next_comm_module( void* arg )
     report_rpc( &cmd, 0, plist_with_buffer(0,strlen(CONFIG.report_server_address)) );
   }
 }
+
 void stream_to_gsm() {
   MIBUnified cmd;
   if ( report_stream_offset >= strlen(base64_report_buffer) )
@@ -322,6 +323,8 @@ void stream_to_gsm() {
 }
 void receive_gsm_stream_response(unsigned char a) 
 {
+  DEBUG_LOGL( "RETURNED" );
+  FLUSH_LOG();
   if ( a != kNoMIBError || current_stream_finished ) {
     if ( a != kNoMIBError )
     {

--- a/momo_modules/shared/pic24/src/core/task_manager.h
+++ b/momo_modules/shared/pic24/src/core/task_manager.h
@@ -12,7 +12,7 @@
 #include "ringbuffer.h"
 #include "rtcc.h"
 
-#define kMAXTASKS 16 //NB Must be a power of 2 since it will be used for a ringbuffer
+#define kMAXTASKS 32 //NB Must be a power of 2 since it will be used for a ringbuffer
 
 typedef enum
 {

--- a/momo_modules/shared/pic24/src/mib/master/bus_master.c
+++ b/momo_modules/shared/pic24/src/mib/master/bus_master.c
@@ -46,7 +46,7 @@ void bus_master_rpc_async_do( void* arg )
 	master_rpcdata = rpc_queue_peek();
 	mib_state.master_callback = master_rpcdata->callback;
 
-	bus_master_sendrpc( NULL );
+	bus_master_sendrpc(NULL);
 	rpc_dequeue(NULL);
 }
 
@@ -65,6 +65,10 @@ void bus_master_rpc_async(mib_rpc_function callback, MIBUnified *data)
 
 void bus_master_sendrpc()
 {
+	//Always clear the rpc_done flag so that we don't repeatedly call sendrpc if someone else does
+	//bus_master_rpc_async before the bus becomes idle. 
+	mib_state.rpc_done = 0;
+
 	//If the bus is not idle do not start an RPC, try later
 	if (!bus_is_idle())
 	{
@@ -74,7 +78,6 @@ void bus_master_sendrpc()
 
 	i2c_master_enable();
 
-	mib_state.rpc_done = 0;
 	set_master_state(kMIBReadReturnStatus);
 	bus_send(master_rpcdata->data.address, (unsigned char *)&(master_rpcdata->data.bus_command), sizeof(MIBCommandPacket)+plist_param_length(master_rpcdata->data.bus_command.param_spec));
 }

--- a/momo_modules/shared/pic24/src/mib/rpc_queue.c
+++ b/momo_modules/shared/pic24/src/mib/rpc_queue.c
@@ -1,5 +1,6 @@
 #include "rpc_queue.h"
 #include "task_manager.h"
+#include "system_log.h"
 #include <string.h>
 
 static rpc_info   the_rpc_queue_data[RPC_QUEUE_SIZE];
@@ -14,6 +15,7 @@ void rpc_queue(mib_rpc_function callback, const MIBUnified *data)
 {
 	uninterruptible_start();
 	if ( rpc_queue_full() ) {
+		CRITICAL_LOGL("RPC Queue Full.");
 		uninterruptible_end();
 		return;  // THIS IS REALLY BAD!!!!!!
 	}

--- a/momo_modules/shared/pic24/src/mib/rpc_queue.c
+++ b/momo_modules/shared/pic24/src/mib/rpc_queue.c
@@ -13,6 +13,10 @@ void rpc_queue_init()
 void rpc_queue(mib_rpc_function callback, const MIBUnified *data)
 {
 	uninterruptible_start();
+	if ( rpc_queue_full() ) {
+		uninterruptible_end();
+		return;  // THIS IS REALLY BAD!!!!!!
+	}
 	rpc_info info;
 	info.callback = callback;
 	memcpy(&info.data, data, sizeof(MIBUnified));

--- a/momo_modules/shared/pic24/src/mib/rpc_queue.h
+++ b/momo_modules/shared/pic24/src/mib/rpc_queue.h
@@ -5,7 +5,7 @@
 
 #include "ringbuffer.h"
 
-#define RPC_QUEUE_SIZE 4 // Must be a power of 2
+#define RPC_QUEUE_SIZE 8 // Must be a power of 2
 
 typedef struct {
 	mib_rpc_function callback;


### PR DESCRIPTION
There were multiple issues with taskloop and rpc queue overflow which led to bus locking occasionally when reporting regularly.

Tested without issue reporting every minute for 3 hours.
