### PR TITLE
Poll for pulse-counted flow rate every 10 seconds, don't count discrete events

### DIFF
--- a/momo_modules/mainboard/src/momo/module_manager.c
+++ b/momo_modules/mainboard/src/momo/module_manager.c
@@ -46,7 +46,7 @@ uint8 module_iter_address( ModuleIterator* iter )
 }
 momo_module_descriptor* module_iter_get( ModuleIterator* iter )
 {
-	if ( iter->current_index == MAX_MODULES )
+	if ( !iter->started || iter->current_index == MAX_MODULES )
 		return NULL;
 	return &the_modules[iter->current_index];
 }

--- a/momo_modules/mainboard/src/momo/report_comm_stream.c
+++ b/momo_modules/mainboard/src/momo/report_comm_stream.c
@@ -45,6 +45,7 @@ void next_comm_module( void* arg )
 {
   module_iter_next( &comm_module_iterator );
   reset_comm_stream();
+  retry_count = 0;
   if ( module_iter_get( &comm_module_iterator ) != NULL )
   {
     open_stream();
@@ -79,10 +80,7 @@ void receive_gsm_stream_response(unsigned char a)
   FLUSH_LOG();
   if ( a != kNoMIBError )
   {
-    CRITICAL_LOGL( "Failed to send a message to a comm module!  Error: " );
-    char buf[4];
-    CRITICAL_LOG( buf, itoa_small( buf, 4, a ) );
-    // taskloop_add( next_comm_module, NULL );
+    write_system_logf( kCriticalLog, "Failed to send a message to a comm module!  Error: %d", a );
     notify_report_failure();
   }
   else if ( !current_stream_finished )
@@ -116,7 +114,6 @@ void report_stream_send( char* buffer )
 {
   report_buffer = buffer;
   comm_module_iterator = create_module_iterator( kMIBCommunicationType );
-  retry_count = 0;
   taskloop_add( next_comm_module, NULL ); 
 }
 
@@ -140,5 +137,6 @@ void notify_report_failure()
   else
   {
     DEBUG_LOGL( "Retry count exceeded, abandoning report." );
+    taskloop_add( next_comm_module, NULL );
   }
 }

--- a/momo_modules/mainboard/src/momo/report_comm_stream.c
+++ b/momo_modules/mainboard/src/momo/report_comm_stream.c
@@ -35,10 +35,10 @@ void reset_comm_stream()
 }
 void open_stream()
 {
-  DEBUG_LOGL( "Opening comm stream..." );
+  write_system_logf( kDebugLog, "Opening comm stream (module: %d, route: %s)", module_iter_address( &comm_module_iterator ), CONFIG.report_server_address );
+
   MIBUnified cmd;
   memcpy( cmd.mib_buffer, CONFIG.report_server_address, strlen(CONFIG.report_server_address) );
-  DEBUG_LOG( cmd.mib_buffer, strlen(CONFIG.report_server_address) );
   report_rpc( &cmd, 0, plist_with_buffer(0,strlen(CONFIG.report_server_address)) );
 }
 void next_comm_module( void* arg )

--- a/momo_modules/mainboard/src/momo/report_manager.c
+++ b/momo_modules/mainboard/src/momo/report_manager.c
@@ -292,8 +292,6 @@ void post_report( void* arg )
     return; //TODO: Recover
   }
   DEBUG_LOGL( "Report constructed:" );
-  DEBUG_LOG( base64_report_buffer, strlen( base64_report_buffer ) );
-
   report_stream_send( base64_report_buffer );
 }
 

--- a/momo_modules/mainboard/src/momo/report_manager.c
+++ b/momo_modules/mainboard/src/momo/report_manager.c
@@ -291,7 +291,7 @@ void post_report( void* arg )
     CRITICAL_LOGL( "Failed to construct report!" );
     return; //TODO: Recover
   }
-  DEBUG_LOGL( "Report constructed:" );
+  DEBUG_LOGL( "Report constructed." );
   report_stream_send( base64_report_buffer );
 }
 

--- a/momo_modules/multi_sensor_module/src/app_main.c
+++ b/momo_modules/multi_sensor_module/src/app_main.c
@@ -94,7 +94,7 @@ void initialize(void)
 	mib_buffer[2] = 8;
 	mib_buffer[3] = 20;
 
-	mib_buffer[4] = kEverySecond;
+	mib_buffer[4] = kEvery10Seconds;
 	mib_buffer[5] = 0;
 	bus_master_prepare_rpc(43, 0, plist_ints(3));
 

--- a/momo_modules/multi_sensor_module/src/app_main.c
+++ b/momo_modules/multi_sensor_module/src/app_main.c
@@ -16,48 +16,31 @@
 MultiSensorState state;
 extern unsigned int adc_result;
 
-static uint16 aggregate_counter;
-
 void task(void)
 {
 	while (state.acquire_pulse)
 	{
 		pulse_sample();
+		state.acquire_pulse = 0;
 
 		if ( state.push_pending )
 		{
-			if ( pulse_count() == 0 )
-			{
-				state.acquire_pulse = 0;
-				state.push_pending = 0;
-				if ( aggregate_counter != 0 )
-				{
-					bus_master_begin_rpc();
-					mib_buffer[0] = mib_address;
-					mib_buffer[1] = 0;
+			state.push_pending = 0;
 
-					mib_buffer[2] = 0;
-					mib_buffer[3] = 0; //metadata
+			bus_master_begin_rpc();
+			mib_buffer[0] = mib_address;
+			mib_buffer[1] = 0;
 
-					mib_buffer[4] = aggregate_counter;
-					mib_buffer[5] = 0;
-					mib_buffer[6] = 0;
-					mib_buffer[7] = 0;
+			mib_buffer[2] = 0;
+			mib_buffer[3] = 0; //metadata
 
-					bus_master_prepare_rpc(70, 0, plist_with_buffer(2, 4));
-					bus_master_send_rpc(8);
+			mib_buffer[4] = pulse_count() & 0xFF;
+			mib_buffer[5] = (pulse_count() >> 8) & 0xFF;
+			mib_buffer[6] = 0;
+			mib_buffer[7] = 0;
 
-					aggregate_counter = 0;
-				}
-			}
-			else
-			{
-				aggregate_counter += pulse_count();
-			}
-		}
-		else
-		{
-			state.acquire_pulse = 0;
+			bus_master_prepare_rpc(70, 0, plist_with_buffer(2, 4));
+			bus_master_send_rpc(8);
 		}
 	}
 }
@@ -102,8 +85,6 @@ void initialize(void)
 
 	damp_init();
 	state.combined_state = 0;
-
-	aggregate_counter = 0;
 
 	bus_master_begin_rpc();
 
@@ -203,7 +184,6 @@ void scheduled_callback()
 {
 	if ( state.acquire_pulse == 0 )
 	{
-		aggregate_counter = 0;
 		state.acquire_pulse = 1;
 		state.push_pending = 1;
 	}

--- a/momo_modules/shared/pic24/src/core/system_log.h
+++ b/momo_modules/shared/pic24/src/core/system_log.h
@@ -7,6 +7,7 @@
 
 #include "platform.h"
 #include "rtcc.h"
+#include <stdarg.h>
 
 #define LOG_ENTRY_SIZE 56
 
@@ -28,6 +29,7 @@ typedef struct
 
 void init_system_log( uint8 start_subsection, uint8 subsection_count );
 void write_system_log( LogStream stream, const BYTE* data, uint8 length );
+void write_system_logf( LogStream stream, const char* fmt, ... );
 bool read_system_log( uint16 offset, LogEntry* out );
 void disable_lazy_logging();
 void clear_system_log();

--- a/tools/bin/modtool.py
+++ b/tools/bin/modtool.py
@@ -447,7 +447,7 @@ class ModTool(cmdln.Cmdln):
 				else:
 					stream = "Unknown (%d)" % stream
 
-				timestamp = datetime.datetime.fromtimestamp(timestamp + 946684800)
+				timestamp = datetime.datetime.fromtimestamp(timestamp + 946684800) # MoMo timestamps begin at 00:00 on January 1, 2000, so add 946684800 to get the actual unix timestamp
 				print "%s (%s) %s" % (stream, timestamp, msg)
 				index += 1
 		elif command == "clear":


### PR DESCRIPTION
This PR relies on #113, the diff from there is rather small.

To minimize power consumption, we now poll for flow rate (by counting half a second of pulses) every 10 seconds, and no longer explicitly measure volume for individual events.
