### PR TITLE
Fix bugs in MoMo reporting firmware

### DIFF
--- a/momo_modules/mainboard/src/momo/module_manager.c
+++ b/momo_modules/mainboard/src/momo/module_manager.c
@@ -17,8 +17,9 @@ uint8 module_count()
 }
 momo_module_descriptor* get_module( uint8 index )
 {
-	if ( index > the_module_count )
+	if ( index >= the_module_count )
 		return NULL;
+
 	return &the_modules[index];
 }
 uint8 get_module_address( uint8 index )
@@ -46,8 +47,9 @@ uint8 module_iter_address( ModuleIterator* iter )
 }
 momo_module_descriptor* module_iter_get( ModuleIterator* iter )
 {
-	if ( !iter->started || iter->current_index == MAX_MODULES )
+	if ( !iter->started || iter->current_index == the_module_count)
 		return NULL;
+	
 	return &the_modules[iter->current_index];
 }
 
@@ -57,11 +59,14 @@ momo_module_descriptor* module_iter_next( ModuleIterator* iter )
 		iter->started = true;
 	else
 		iter->current_index += 1;
-	while ( iter->current_index < MAX_MODULES && the_modules[iter->current_index].module_type != iter->module_type )
+
+	while ( iter->current_index < the_module_count && the_modules[iter->current_index].module_type != iter->module_type )
 	{
 		iter->current_index += 1;
 	}
-	if ( iter->current_index == MAX_MODULES )
+	
+	if ( iter->current_index == the_module_count)
 		return NULL;
+	
 	return &the_modules[iter->current_index];
 }

--- a/momo_modules/mainboard/src/momo/momo_config.c
+++ b/momo_modules/mainboard/src/momo/momo_config.c
@@ -45,7 +45,7 @@ void flush_config_to_memory( void* arg )
 void save_momo_state()
 {
   if ( config_state == kClean )
-    scheduler_schedule_task( flush_config_to_memory, kEveryHalfSecond, 1, &flush_config_task, NULL );
+    scheduler_schedule_task( flush_config_to_memory, kEverySecond, 1, &flush_config_task, NULL );
   config_state = kDirty;
 }
 

--- a/momo_modules/mainboard/src/momo/report_comm_stream.h
+++ b/momo_modules/mainboard/src/momo/report_comm_stream.h
@@ -7,4 +7,6 @@ void report_stream_send( char* buffer );
 void notify_report_success();
 void notify_report_failure();
 
+void init_comm_stream();
+
 #endif

--- a/momo_modules/mainboard/src/momo/report_manager.c
+++ b/momo_modules/mainboard/src/momo/report_manager.c
@@ -83,6 +83,8 @@ void init_report_config()
 
   //Make sure we initialize this scheduled task.
   report_task.flags = 0;
+
+  init_comm_stream();
 }
 
 void update_interval_headers( sms_report* header, AlarmRepeatTime interval )
@@ -306,9 +308,11 @@ void stop_report_scheduling() {
 void set_report_scheduling_interval( AlarmRepeatTime interval ) {
   if ( interval >= kNumAlarmTimes )
     return;
+
   CONFIG.report_interval = interval;
   if ( BIT_TEST(report_task.flags, kBeingScheduledBit) )
     scheduler_schedule_task( post_report, CONFIG.report_interval, kScheduleForever, &report_task, NULL );
+  
   save_momo_state();
 }
 void set_report_server_address( const char* address, uint8 len )

--- a/momo_modules/shared/pic24/src/core/scheduler.c
+++ b/momo_modules/shared/pic24/src/core/scheduler.c
@@ -53,8 +53,10 @@ void scheduler_schedule_task( task_callback func,
 
 void scheduler_remove_task(ScheduledTask *task)
 {
-	int list = task->flags & kScheduleFrequencyMask;
+	if (!BIT_TEST(task->flags, kBeingScheduledBit))
+		return;
 
+	int list = task->flags & kScheduleFrequencyMask;
 	scheduler_list_remove(&state.tasks[list], task);
 }
 


### PR DESCRIPTION
Major issue was that the debug log flush event was causing post_report to be double scheduled, leading to two post_report tasks running in parallel and interfering with each other / destroying everything.  This is because flush_log scheduled itself with a 0.5 second delay meaning that it ran in the same second as post_report if post_report finished quickly.  Since the seconds matched, the RTCC would schedule post_report again leading to it being scheduled twice in tandem.  There were other off by one errors and issues with module iteration that I believe are fixed now but I'm not sure if they were causing any harm.

MoMo is currently reporting with a 1 minute interval and seems to be doing fine. 
