### PR TITLE
Fix 'momo build' on Windows

### DIFF
--- a/tools/site_scons/pic12.py
+++ b/tools/site_scons/pic12.py
@@ -118,4 +118,4 @@ def compile_mib(env):
 
 	env['MIBFILE'] = '#' + cmdmap_path
 
-	return env.Command(cmdmap_path, mibname, 'mibtool gen -o %s $SOURCE' % dirs['build'])
+	return env.Command(cmdmap_path, mibname, 'python ../../tools/bin/mibtool.py gen -o %s $SOURCE' % dirs['build'])


### PR DESCRIPTION
On Windows, you can't call python tools (like 'momo' and 'mibtool') directly since there's no concept of executable shells. This change fixes the Windows 8-bit module build system by invoking 'python ../../tools/bin/mibtool.py' instead of 'mibtool'.
