### PR TITLE
CRITICAL: Fix bootloader not writing last 32 bytes of ROM sometimes.

### DIFF
--- a/momo_modules/pic12_executive/src/bootloader.c
+++ b/momo_modules/pic12_executive/src/bootloader.c
@@ -52,7 +52,7 @@ void enter_bootloader()
 	{
 		++boot_count;
 
-    	invalid_row = 0;
+    	invalid_row = 1;
 
     	for (offset = 0; offset < kBootloaderBufferSize; offset += kMIBRequestSize)
     		get_half_row(); //offset is passed through global

--- a/momo_modules/pic12_executive/src/bootloader_asm.as
+++ b/momo_modules/pic12_executive/src/bootloader_asm.as
@@ -51,8 +51,12 @@ BEGINFUNCTION _get_half_row
 	movf BANKMASK(_boot_source),w
 	call _bus_master_send_rpc
 
+	;Make sure that if any of the calls to get half_row succeed then we program the
+	;entire row.
 	banksel _invalid_row
-	iorwf BANKMASK(_invalid_row),f
+	iorlw 0x00 ;Make sure that the ZERO flag is set if it's 0
+	btfsc ZERO
+		clrf BANKMASK(_invalid_row),f
 
 	;Load the offset that we should copy to here
 	banksel _offset


### PR DESCRIPTION
Due to a terrible bug in the bootloading code of the pic12_executive, it will sometimes not write the last 32 bytes of ROM on pic 16lf1847 chips.  This is because it has to fetch the ROM in 2 calls since the rows are 32 bytes wide on this chip.  The bootloader checks to see if each half page is defined in the controller firmware_cache and **if either half-page is not defined** it does not program **the entire page**.  To hit this bug you would need to have a firmware with length longer than 2k because otherwise the entire last page would always be filled by the mib block.  You also need to end on an address that it >= 0 but less than 16 so that you touch another page but don't touch the high half-page.  

The fix is to change the check for valid pages so that if either half-page is valid, the entire page is written.  Turns out the gsm module code (with my changes, not sure about before but probably) was sometimes falling into this regime and having the string constants replaced by 0xFF (the unprogrammed ROM value).
## Actions
- All bootloaders should be updated to this version
- Application code should be reflashed onto them.  
