### PR TITLE
Automate gpsim installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 	  momo.vm.network "forwarded_port", guest: 80, host: 1111
 
-	  momo.vm.provision "shell", inline: "MOMO_DEV=true; /vagrant/tools/automation/provision.sh"
+	  momo.vm.provision "shell", inline: "export MOMO_DEV=true; /vagrant/tools/automation/provision.sh"
 	end
 end

--- a/tools/automation/install_patched_gpsim.sh
+++ b/tools/automation/install_patched_gpsim.sh
@@ -1,0 +1,32 @@
+echo "Patching GPSIM..."
+set -e
+
+apt-get install -y g++ subversion automake make libglib2.0-dev pkg-config libpopt-dev libtool flex bison
+
+rm -rf gputils
+mkdir gputils
+cd gputils
+
+svn checkout svn://svn.code.sf.net/p/gputils/code/trunk/gputils -r 1128 .
+
+./configure
+make
+make install
+
+cd ..
+
+rm -rf gpsim
+mkdir gpsim
+cd gpsim
+
+svn checkout svn://svn.code.sf.net/p/gpsim/code/trunk -r 2299 .
+patch -p0 -i $MOMOPATH/support/gpsim_16lf1847_support.patch
+
+libtoolize --force
+aclocal
+autoheader
+automake --force-missing --add-missing
+autoconf
+./configure --disable-gui
+make
+make install

--- a/tools/automation/provision.sh
+++ b/tools/automation/provision.sh
@@ -8,7 +8,7 @@ echo "MOMO_DEV: $MOMO_DEV"
 apt-get update
 apt-get install -y python python-setuptools python-dev python-pip
 if [ -n "$MOMO_DEV" ]; then
-	apt-get install -y libc6:i386 lib32stdc++6 gpsim
+	apt-get install -y libc6:i386 lib32stdc++6
 fi
 apt-get install wget
 
@@ -22,12 +22,12 @@ PYTHONPATH=`cat $HOME/scons-install.log | grep ' library modules ' | awk '{print
 echo "PYTHONPATH=$PYTHONPATH" >> $HOME/.profile
 
 if [ -n "$TRAVIS" ]; then
-	MOMOPATH=`pwd`
-	DOWNLOADCACHE="~/.cached_downloads"
+	export MOMOPATH=`pwd`
+	export DOWNLOADCACHE="~/.cached_downloads"
 else # VAGRANT
-	MOMOPATH="/vagrant"
-	HOME="/home/vagrant"
-	DOWNLOADCACHE="/vagrant/.cached_downloads"
+	export MOMOPATH="/vagrant"
+	export HOME="/home/vagrant"
+	export DOWNLOADCACHE="/vagrant/.cached_downloads"
 
 	echo "Adding user 'vagrant' to the group 'dialout' so it can access USB devices..."
 	usermod vagrant -a -G dialout
@@ -86,25 +86,10 @@ if [ -n "$MOMO_DEV" ]; then
 		die "Failed to install xc16, exiting!"
 	fi
 	echo "DONE!"
+
+	cd $HOME
+	$MOMOPATH/tools/automation/install_patched_gpsim.sh
 fi
-
-# echo "Patching GPSIM..."
-
-# apt-get install -y subversion automake make libglib2.0-dev pkg-configure libpopt-dev libtool flex bison
-
-# mkdir gpsim
-# cd gpsim
-# svn checkout svn://svn.code.sf.net/p/gpsim/code/trunk -r 2281 .
-# patch -p0 -i $MOMOPATH/support/gpsim_16lf1847_support.patch
-
-# libtoolize --force
-# aclocal
-# autoheader
-# automake --force-missing --add-missing
-# autoconf
-# ./configure
-# make
-# sudo make install
 
 echo "DONE!"
 


### PR DESCRIPTION
This automates the installation of a patched GPSIM in infrastructure-as-code environments such as Vagrant boxes and continuous integration VMs.  The installation is not quick (perhaps we should create a GPSIM fork and which exposes a pre-compiled executable until such time as our changes are accepted upstream) but should facilitate automatic 8-bit unit test execution.
