### PR TITLE
Update multisensor board to make sensing more robust

### DIFF
--- a/momo_modules/multi_sensor_module/src/mib/multi_sensor_module.mib
+++ b/momo_modules/multi_sensor_module/src/mib/multi_sensor_module.mib
@@ -10,5 +10,8 @@ feature 20
 4: _power_analog(1, no);
 5: _acquire_voltage(0, no);
 6: _acquire_pulse(0, no);
-7: _read_pulses(0, no);
-8: _clear_counters(0, no);
+7: _number_of_pulses(0, no);
+8: _read_pulse(1, no);
+9: _read_periods(0, no);
+10: _read_median_interval(0, no);
+11: _set_push_status(1, no);

--- a/momo_modules/multi_sensor_module/src/pulse.c
+++ b/momo_modules/multi_sensor_module/src/pulse.c
@@ -3,12 +3,32 @@
 #include "sample.h"
 #include "port.h"
 #include "ioc.h"
+#include "timer1.h"
 #include "ccp.h"
 #include <xc.h>
 
+#define kTimer1_HalfSecond 3036
 
-uint16_t counter;
-uint16_t periods;
+#define MAX_PULSES		20		//Must be less than 256
+
+//Discard all pulses with width shorter than this
+#define MIN_PULSE_WIDTH	(125UL*5UL) //5 ms in units of tmr1 counts (8 us)
+
+//Discard all pulses that are closer to eachother than this value.
+//This limits the highest flowrate that can be counted.  With the
+//Digisavant 8800H (1" flow sensor) there are 65 pulses per liter
+//so 25 ms would be (1000/25./65) .6 liters per second, which is a lot.
+#define MIN_PULSE_DELAY (125UL*25UL) //25 ms in units of tmr1 counts (8 us)
+
+uint8_t periods;
+
+uint16_t pulse_widths[MAX_PULSES];
+uint16_t pulse_intervals[MAX_PULSES];
+uint16_t pulse_temp_intervals[MAX_PULSES];
+uint16_t pulse_start;
+uint16_t last_valid_start;
+uint8_t  pulses;
+uint8_t  invalid_pulses;
 
 void pulse_readone();
 
@@ -18,39 +38,161 @@ void pulse_sample()
 	set_analog_power(1);
 
 	/*
-	 * Count pulses for 0.1 seconds
+	 * Count pulses for 500 ms recording the number
+	 * of complete pulses (falling edge, low period, rising edge)
 	 */
 
-	++periods;
-
-	tmr_config(2, kTMRPrescale_64, kTMRPostscale1_16);
-	tmr_loadperiod(2, 98);
-	tmr_load(2, 0);
-	tmr_flag(2) = 0;
-	tmr_setstate(2, 1);
+	pulses = 0;
+	invalid_pulses = 0;
+	pulse_start = 0;
+	last_valid_start = 0;
 	
+	//Use 16 bit timer to capture pulse widths and intervals
+	tmr1_config(pack_tmr1_config(kInstructionClock, kPrescaler1_8));
+	tmr1_load(kTimer1_HalfSecond);
+	tmr1_setstate(kEnabled_Sync);
+
 	//Wait for the pin to go high so that we have a valid signal
-	while(PIN(PULSE_IN) == 0 && tmr_flag(2) == 0)
+	while(PIN(PULSE_IN) == 0 && tmr1_flag == 0)
 		;
 	
-	if (tmr_flag(2) == 0)
+	if (tmr1_flag == 0)
 	{
 		ioc_flag_b(PULSE_IOC) = 0;
 		ioc_detect_falling_b(PULSE_IOC, 1);
+		ioc_detect_rising_b(PULSE_IOC, 1);
 
-		while(tmr_flag(2) == 0)
+		//Actual counting happens in interrupt code
+		while(tmr1_flag == 0)
 			;
 
 		//Disable everything
 		ioc_detect_falling_b(PULSE_IOC, 0);
+		ioc_detect_rising_b(PULSE_IOC, 0);
 	}
 
-	tmr_setstate(2, 0);
+	tmr1_setstate(kDisabled);
 	set_analog_power(0);
 	PIN_DIR(PULSE_IN, OUTPUT);
 }
 
+void pulse_falling_edge()
+{
+	pulse_start = tmr1_get();
+}
+
+void pulse_rising_edge()
+{
+	uint16_t pulse_end = tmr1_get();
+	uint16_t temp = pulse_end - pulse_start;
+
+	//Make sure the pulse was a certain width
+	if (temp <= MIN_PULSE_WIDTH)
+	{
+		++invalid_pulses;
+		return;
+	}
+
+	//Make sure the pulse is delayed by at least a certain
+	//amount
+	if (pulses > 0)
+	{
+		temp = pulse_start - last_valid_start;
+		if (temp <= MIN_PULSE_DELAY)
+		{
+			++invalid_pulses;
+			return;
+		}
+	}
+
+	if (pulses < MAX_PULSES)
+	{
+		pulse_widths[pulses] = pulse_end - pulse_start;
+
+		if (pulses > 0)
+			pulse_intervals[pulses-1] = pulse_start - last_valid_start;
+
+		++pulses;
+	}
+
+	last_valid_start = pulse_start;
+}
+
+uint8_t pulse_find_lowest_interval()
+{
+	uint8_t i;
+	uint8_t lowest_i = 0;
+	uint16_t lowest = 65535;
+
+	for (i=0; i<(pulses-1); ++i)
+	{
+		if (pulse_temp_intervals[i] < lowest)
+		{
+			lowest = pulse_temp_intervals[i];
+			lowest_i = i;
+		}
+	}
+
+	return lowest_i;
+}
+
+/*
+ * Destructively compute the median value of the list of pulse intervals
+ * Use median instead of mean so that we're not sensitive to outliers.
+ * This could be optimized by using the Selection Algorithm rather than
+ * the slow one here, but since pulse_intervals is limited to < 20 entries
+ * it should be fine.
+ */
+
+uint16_t pulse_median_interval()
+{
+	uint8_t i;
+	uint8_t midpoint;
+
+	if (pulses < 2)
+		return 0;
+
+	if (pulses == 2)
+		return pulse_intervals[0];
+
+	midpoint = (pulses-1) >> 1;
+
+	//Make a temporary copy that we can destructively modify to find the median
+	for (i=0; i<pulses; ++i)
+		pulse_temp_intervals[i] = pulse_intervals[i];
+
+	for (i=0; i<midpoint; ++i)
+	{
+		uint8_t low_i = pulse_find_lowest_interval();
+		pulse_temp_intervals[low_i] = 65535;
+	}
+
+	i = pulse_find_lowest_interval();
+	return pulse_temp_intervals[i];
+}
+
 uint16_t pulse_count()
 {
-	return counter;
+	return pulses;
+}
+
+uint16_t pulse_invalid_count()
+{
+	return invalid_pulses;
+}
+
+uint16_t pulse_width(uint8_t pulse)
+{
+	if (pulse >= pulses)
+		return -1;
+
+	return pulse_widths[pulse];
+}
+
+uint16_t pulse_interval(uint8_t pulse)
+{
+	if (pulse >= (pulses-1))
+		return -1;
+
+	return pulse_intervals[pulse];
 }

--- a/momo_modules/multi_sensor_module/src/pulse.h
+++ b/momo_modules/multi_sensor_module/src/pulse.h
@@ -5,5 +5,11 @@
 
 void 		pulse_sample();
 uint16_t 	pulse_count();
+uint16_t 	pulse_invalid_count();
+uint16_t 	pulse_width(uint8_t pulse);
+uint16_t 	pulse_interval(uint8_t pulse);
+uint16_t 	pulse_median_interval();
 
+void		pulse_falling_edge();
+void		pulse_rising_edge();
 #endif

--- a/momo_modules/multi_sensor_module/src/state.h
+++ b/momo_modules/multi_sensor_module/src/state.h
@@ -11,7 +11,8 @@ typedef struct
 		{
 			uint8_t acquire_pulse : 1;
 			uint8_t push_pending : 1;
-			uint8_t reserved : 6;
+			uint8_t push_disabled: 1;
+			uint8_t reserved : 5;
 		};
 
 		uint8_t combined_state;

--- a/momo_modules/shared/pic12/src/peripheral/timer1.h
+++ b/momo_modules/shared/pic12/src/peripheral/timer1.h
@@ -30,10 +30,11 @@ enum
 
 #define kHalfSecondConstant 3036UL
 
-#define tmr1_load( value) {	\
+#define tmr1_load(value) {	\
 	TMR1L = value & 0xFF; 	\
 	TMR1H = (value >> 8);}
 
+#define tmr1_flag		TMR1IF
 #define tmr1_get() ((((uint16_t)TMR1H) << 8) | TMR1L)
 #define tmr1_config(config) T1CON = config
 #define tmr1_setstate(state) {\

--- a/momo_modules/shared/pic12/src/watchdog.h
+++ b/momo_modules/shared/pic12/src/watchdog.h
@@ -11,8 +11,10 @@
 
 enum
 {
-	k1SecondTimeout = 0b010100,
-	k4SecondTimeout = 0b011000
+	k1SecondTimeout  = 0b010100,
+	k4SecondTimeout  = 0b011000,
+	k8SecondTimeout  = 0b011010,
+	k16SecondTimeout = 0b011100
 };
 
 void wdt_pushenabled();


### PR DESCRIPTION
Replace the old algorithm for figuring out the flow rate with a new one based on taking the median interval between pulses to figure out the pulse per second rate and using that to infer the flow rate.

New algorithm is:
- sample pulses for half a second at a time and count the first (up to) 20 pulses you see
  that meet a minimum length and minimum delay criteria designed to ward off fake jitter pulses.
- find the median pulse interval of all the intervals you see.  Use the median so that the result
  is insensitive to high outliers
- convert that median interval to a median pulse per second rate
- average the median rates from each sampling period and report that once per minute

The flow rate is sampled once per 16 seconds now in order to keep the power consumption (on/off ratio)
about the same as before, though a little higher. (.1/4 vs .5/16)
