### PR TITLE
Implement some robustness improvements for the Tanzania pilot deployment.

### DIFF
--- a/momo_modules/gsm_module/src/gprs.c
+++ b/momo_modules/gsm_module/src/gprs.c
@@ -25,7 +25,7 @@ bool gprs_connect()
 	gsm_cmd( "AT+SAPBR=3,1,\"Contype\",\"GPRS\"" );
 	__delay_ms(100);
 	
-	uint8 retry_count = 2;
+	uint8 retry_count = 4;
 	do
 	{
 		//Need to wait a longer time for this command because it can take > 3s to return
@@ -38,7 +38,7 @@ bool gprs_connect()
 		}
 
 		__delay_ms(5000);
-	} while ( retry_count-- > 0 );
+	} while ( --retry_count > 0 );
 
 	
 	return false;

--- a/momo_modules/gsm_module/src/gsm.c
+++ b/momo_modules/gsm_module/src/gsm.c
@@ -39,7 +39,7 @@ bool gsm_on()
 
 bool gsm_register()
 {
-	uint8 timeout_s = 240;
+	uint8 timeout_s = GSM_REGISTRATION_TIMEOUT_S;
 	while ( !gsm_registered() )
 	{
 		if ( timeout_s-- == 0 )
@@ -66,7 +66,7 @@ void gsm_remember_band()
 	gsm_cmd_raw( "AT+CBAND?" , kDEFAULT_CMD_TIMEOUT );
 	
 	uint8 i = 0;
-	while ( sticky_band[i] != '\0' && sticky_band[i] != ',' && sticky_band[i] != '\r' && i++ < sizeof(sticky_band) )
+	while ( sticky_band[i] != '\0' && sticky_band[i] != ',' && sticky_band[i] != '\r' && i++ < sizeof(sticky_band)-1 )
 		continue;
 	sticky_band[i] = '\0';
 }

--- a/momo_modules/gsm_module/src/gsm.h
+++ b/momo_modules/gsm_module/src/gsm.h
@@ -8,6 +8,8 @@
 
 #define kDEFAULT_CMD_TIMEOUT 2
 
+#define GSM_REGISTRATION_TIMEOUT_S 120
+
 void gsm_init();
 bool gsm_on();
 

--- a/momo_modules/mainboard/module_settings.json
+++ b/momo_modules/mainboard/module_settings.json
@@ -18,6 +18,7 @@
 				"mainboard/src/mib/commands",
 				"mainboard/src/modules",
 				"mainboard/src/momo",
+				"mainboard/src/diagnostics",
 				"mainboard/src/util"
 			]
 		}

--- a/momo_modules/mainboard/src/core/mainboard_reset_handler.c
+++ b/momo_modules/mainboard/src/core/mainboard_reset_handler.c
@@ -17,6 +17,7 @@
 #include "perf.h"
 #include "momo_config.h"
 #include "log_definitions.h"
+#include "sanity_check.h"
 #include "rn4020.h"
 
 static bool mclr_triggered;
@@ -72,6 +73,7 @@ void handle_all_resets_after(unsigned int type)
 
     battery_init();
     //bt_init();
+    sanity_check_schedule();
     report_manager_start();
 
     LOG_CRITICAL(kDeviceInitializedNotice);

--- a/momo_modules/mainboard/src/diagnostics/sanity_check.c
+++ b/momo_modules/mainboard/src/diagnostics/sanity_check.c
@@ -1,0 +1,36 @@
+#include "sanity_check.h"
+#include "scheduler.h"
+#include "module_manager.h"
+#include "system_log.h"
+#include "log_definitions.h"
+#include "bus_master.h"
+#include "rtcc.h"
+
+ScheduledTask sanity_check_task;
+
+void sanity_check_schedule()
+{
+	scheduler_schedule_task( sanity_check_run, kEveryHour, kScheduleForever, &sanity_check_task, NULL );
+}
+
+void sanity_check_run( void* arg )
+{
+	uint8 count = module_count();
+	
+	rtcc_timestamp now = rtcc_get_timestamp();
+	TimeIntervalDirection dir;
+	uint32 diff = 0;
+	if ( bus_master_rpc_start_timestamp() != 0 )
+		diff = rtcc_timestamp_difference( bus_master_rpc_start_timestamp(), now, &dir );
+
+	if ( count != SANITY_CHECK_MODULE_COUNT 
+	  || diff > 60 * SANITY_CHECK_HUNG_BUS_TIMEOUT_M )
+	{
+		LOG_CRITICAL(kSanityCheckResetNotice);
+		LOG_INT(SANITY_CHECK_MODULE_COUNT);
+		LOG_INT(count);
+		LOG_INT(diff);
+		LOG_FLUSH();
+		asm volatile("reset");
+	}
+}

--- a/momo_modules/mainboard/src/diagnostics/sanity_check.h
+++ b/momo_modules/mainboard/src/diagnostics/sanity_check.h
@@ -1,0 +1,9 @@
+#ifndef __sanity_check_h__
+#define __sanity_check_h__
+
+#define SANITY_CHECK_MODULE_COUNT 2 //TODO: make configurable
+#define SANITY_CHECK_HUNG_BUS_TIMEOUT_M 30
+void sanity_check_schedule();
+void sanity_check_run( void* arg );
+
+#endif

--- a/momo_modules/mainboard/src/log_definitions.ldf
+++ b/momo_modules/mainboard/src/log_definitions.ldf
@@ -24,6 +24,19 @@ ControllerFactoryResetNotice
 "The MoMo controller is performing a factory reset"
 
 
+SanityCheckNotice
+"Running sanity check"
+- "rpc_start_time" as integer, format unsigned
+- "Now" as integer, format unsigned
+- "Diff" as integer, format unsigned
+
+SanityCheckResetNotice
+"The regular sanity check failed, resetting."
+- "Expected Modules" as integer, format unsigned
+- "Attached Modules" as integer, format unsigned
+- "RPC Hang Delay" as integer, format unsigned
+
+
 SubmoduleAddressRequestNotice
 "A submodule asked for an address"
 

--- a/momo_modules/mainboard/src/momo/report_manager.c
+++ b/momo_modules/mainboard/src/momo/report_manager.c
@@ -64,8 +64,9 @@ char                  base64_report_buffer[BASE64_REPORT_MAX_LENGTH+1];
 static sensor_event   event_buffer[EVENT_BUFFER_SIZE];
 
 //TODO: Implement dynamic report routing based on an initial "registration" ping to the coordinator address
-#define DEFAULT_WEB_ROUTE "http://strato.welldone.org/gateway/post"
+#define DEFAULT_WEB_ROUTE "https://strato.welldone.org/gateway/http"
 #define DEFAULT_SMS_ROUTE "+14159928370"
+// UK ALT +447903568420
 #define DEFAULT_GPRS_APN "JTM2M"
 
 extern unsigned int last_battery_voltage;

--- a/momo_modules/multi_sensor_module/src/app_main.c
+++ b/momo_modules/multi_sensor_module/src/app_main.c
@@ -36,7 +36,7 @@ void task(void)
 		++periods;
 	}
 
-	if (state.push_pending && (!state.push_disabled))
+	if (state.push_pending)
 	{
 		uint16_t average_flow = 0;
 		

--- a/momo_modules/shared/pic24/src/mib/master/bus_master.c
+++ b/momo_modules/shared/pic24/src/mib/master/bus_master.c
@@ -12,6 +12,8 @@ void 			bus_master_rpc_async_do();
 
 const rpc_info *master_rpcdata;
 
+rtcc_timestamp rpc_start_time;
+
 unsigned int bus_master_idle()
 {
 	return mib_state.rpc_done;
@@ -23,6 +25,7 @@ static void bus_master_finish()
 
 	//Set the flag that this RPC is done for whomever is waiting.
 	mib_state.rpc_done = 1;
+	rpc_start_time = 0;
 
 	if ( !rpc_queue_empty() )
 			taskloop_add_critical( bus_master_rpc_async_do, NULL );
@@ -38,6 +41,7 @@ static void bus_master_finish()
 void bus_master_init()
 {
 	mib_state.rpc_done = 1;
+	rpc_start_time = 0;
 	rpc_queue_init();
 }
 
@@ -76,6 +80,7 @@ void bus_master_sendrpc()
 		return;
 	}
 
+	rpc_start_time = rtcc_get_timestamp();
 	i2c_master_enable();
 
 	set_master_state(kMIBReadReturnStatus);
@@ -151,4 +156,9 @@ void bus_master_callback()
 			bus_master_finish();
 		break;
 	}
+}
+
+rtcc_timestamp bus_master_rpc_start_timestamp()
+{
+	return rpc_start_time;
 }

--- a/momo_modules/shared/pic24/src/mib/master/bus_master.h
+++ b/momo_modules/shared/pic24/src/mib/master/bus_master.h
@@ -2,10 +2,12 @@
 #define __bus_master_h__
 
 #include "bus.h"
+#include "rtcc.h"
 
 //Master Routines
 void bus_master_callback();
 void bus_master_rpc_async(mib_rpc_function callback, MIBUnified *data);
 void bus_master_init();
 unsigned int bus_master_idle();
+rtcc_timestamp bus_master_rpc_start_timestamp();
 #endif

--- a/tools/automation/build_all.sh
+++ b/tools/automation/build_all.sh
@@ -1,12 +1,14 @@
 set -e
 source $HOME/.profile
 if [ "$1" == "pro" ]; then
-	cd $MOMOPATH/momo_modules/gsm_module && momo build
-	cd $MOMOPATH/momo_modules/pic12_executive && momo build
+	cd $MOMOPATH/momo_modules/pic12_executive && momo build test && momo build
+	cd $MOMOPATH/momo_modules/gsm_module && momo build test
 else
 	echo "Skipping modules that require XC8 PRO"
 fi
-cd $MOMOPATH/momo_modules/multi_sensor_module && momo build -c && momo build
+cd $MOMOPATH/momo_modules/gsm_module && momo build -c && momo build
+cd $MOMOPATH/momo_modules/multi_sensor_module && momo build -c && momo build test && momo build
+
 cd $MOMOPATH/momo_modules/shared/pic24 && momo build -c && momo build
 cd $MOMOPATH/momo_modules/mainboard && momo build -c && momo build 
 cd $MOMOPATH/momo_modules/field_service_unit && momo build -c && momo build


### PR DESCRIPTION
Add a sanity check for a controller-initiated RPC that has been running for more than 30 minutes and reset because some slave has probably locked the bus.
